### PR TITLE
fix: resolve build errors for Vercel deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "eslint-config-next": "15.5.4",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
-        "typescript": "^5"
+        "typescript": "5.9.3"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "eslint-config-next": "15.5.4",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5"
+    "typescript": "5.9.3"
   }
 }

--- a/src/app/api/templates/send/route.ts
+++ b/src/app/api/templates/send/route.ts
@@ -9,6 +9,7 @@ type TemplatePayload = TemplateMessageInput['template'];
 type TemplateBodyParameter = NonNullable<TemplateSendInput['body']>[number];
 type TemplateHeaderParameter = Extract<NonNullable<TemplateSendInput['header']>, { type: 'text' }>;
 type TemplateButtonParameter = Extract<NonNullable<TemplateSendInput['buttons']>[number], { subType: 'url' }>;
+type ButtonTextParameter = { type: 'text'; text: string; parameter_name?: string };
 
 export async function POST(request: Request) {
   try {
@@ -88,7 +89,7 @@ export async function POST(request: Request) {
             type: 'text',
             text: textValue,
             parameter_name: paramDef.name
-          } as any);
+          } as ButtonTextParameter);
         }
       });
 

--- a/src/lib/whatsapp-client.ts
+++ b/src/lib/whatsapp-client.ts
@@ -1,9 +1,27 @@
 import { WhatsAppClient } from '@kapso/whatsapp-cloud-api';
 
-export const whatsappClient = new WhatsAppClient({
-  baseUrl: 'https://api.kapso.ai/meta/whatsapp',
-  kapsoApiKey: process.env.KAPSO_API_KEY!,
-  graphVersion: 'v24.0'
+let _whatsappClient: WhatsAppClient | null = null;
+
+export function getWhatsAppClient(): WhatsAppClient {
+  if (!_whatsappClient) {
+    const kapsoApiKey = process.env.KAPSO_API_KEY;
+    if (!kapsoApiKey) {
+      throw new Error('KAPSO_API_KEY environment variable is not set');
+    }
+    _whatsappClient = new WhatsAppClient({
+      baseUrl: 'https://api.kapso.ai/meta/whatsapp',
+      kapsoApiKey,
+      graphVersion: 'v24.0'
+    });
+  }
+  return _whatsappClient;
+}
+
+// Lazy getter for backwards compatibility
+export const whatsappClient = new Proxy({} as WhatsAppClient, {
+  get(_, prop) {
+    return getWhatsAppClient()[prop as keyof WhatsAppClient];
+  }
 });
 
-export const PHONE_NUMBER_ID = process.env.PHONE_NUMBER_ID!;
+export const PHONE_NUMBER_ID = process.env.PHONE_NUMBER_ID || '';


### PR DESCRIPTION
## Summary
- Fix TypeScript ESLint error (`@typescript-eslint/no-explicit-any`) in template send route
- Fix build-time initialization error by implementing lazy client initialization

## Problem
The build was failing on Vercel with two issues:
1. `Unexpected any` error at `src/app/api/templates/send/route.ts:91`
2. `Must provide either an accessToken or kapsoApiKey` error during page data collection

## Solution
1. **TypeScript fix**: Added proper `ButtonTextParameter` type definition instead of using `as any`
2. **Lazy initialization**: Changed `whatsappClient` from eager initialization to lazy initialization using a Proxy pattern, so the client is only instantiated at runtime when actually used, not during the Next.js build process

## Test plan
- [x] `npm run build` passes successfully
- [x] All API routes compile without TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)