### PR TITLE
feat: make API base URL configurable via WHATSAPP_API_URL env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 PHONE_NUMBER_ID=
 KAPSO_API_KEY=
 WABA_ID=
+# Optional: custom API endpoint (defaults to https://api.kapso.ai/meta/whatsapp)
+WHATSAPP_API_URL=

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Create `.env`:
 PHONE_NUMBER_ID=your_phone_number_id
 KAPSO_API_KEY=your_kapso_api_key
 WABA_ID=your_business_account_id
+WHATSAPP_API_URL=https://api.kapso.ai/meta/whatsapp  # Optional: custom API endpoint
 ```
 
 ### 4. Run

--- a/src/lib/whatsapp-client.ts
+++ b/src/lib/whatsapp-client.ts
@@ -9,7 +9,7 @@ export function getWhatsAppClient(): WhatsAppClient {
       throw new Error('KAPSO_API_KEY environment variable is not set');
     }
     _whatsappClient = new WhatsAppClient({
-      baseUrl: 'https://api.kapso.ai/meta/whatsapp',
+      baseUrl: process.env.WHATSAPP_API_URL || 'https://api.kapso.ai/meta/whatsapp',
       kapsoApiKey,
       graphVersion: 'v24.0'
     });


### PR DESCRIPTION
Closes #4

This allows users to point Cloud Inbox at their own Kapso-compatible API endpoint by setting the `WHATSAPP_API_URL` environment variable.

If unset, it defaults to Kapso's hosted API, maintaining backwards compatibility.

**Use case:** Self-hosting a backend that returns Kapso-shaped responses, enabling Cloud Inbox as a UI layer for custom WhatsApp integrations.