### PR TITLE
feat: improve mobile experience - safe areas, dvh, viewport meta

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -124,6 +124,16 @@
   }
 }
 
+/* Safe area insets for notched phones (iPhone X+) */
+@supports (padding: env(safe-area-inset-bottom)) {
+  .safe-area-bottom {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+  .safe-area-top {
+    padding-top: env(safe-area-inset-top);
+  }
+}
+
 /* Fix ScrollArea table layout breaking text truncation */
 [data-radix-scroll-area-viewport] > div {
   display: block !important;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,13 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import "./globals.css";
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+  viewportFit: "cover",
+};
 
 export const metadata: Metadata = {
   title: "WhatsApp inbox",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,7 +32,7 @@ export default function Home() {
   };
 
   return (
-    <div className="h-screen flex">
+    <div className="h-dvh flex">
       <ConversationList
         ref={conversationListRef}
         onSelectConversation={setSelectedConversation}

--- a/src/components/conversation-list.tsx
+++ b/src/components/conversation-list.tsx
@@ -135,10 +135,10 @@ export const ConversationList = forwardRef<ConversationListRef, Props>(
   if (loading) {
     return (
       <div className={cn(
-        "w-full md:w-96 border-r border-[#d1d7db] bg-white flex flex-col",
+        "w-full md:w-96 md:border-r border-[#d1d7db] bg-white flex flex-col",
         isHidden && "hidden md:flex"
       )}>
-        <div className="p-4 border-b border-[#d1d7db] bg-[#f0f2f5]">
+        <div className="p-4 border-b border-[#d1d7db] bg-[#f0f2f5] safe-area-top">
           <div className="flex items-center justify-between mb-3">
             <Skeleton className="h-7 w-20" />
             <Skeleton className="h-9 w-24" />
@@ -162,10 +162,10 @@ export const ConversationList = forwardRef<ConversationListRef, Props>(
 
   return (
     <div className={cn(
-      "w-full md:w-96 border-r border-[#d1d7db] bg-white flex flex-col",
+      "w-full md:w-96 md:border-r border-[#d1d7db] bg-white flex flex-col",
       isHidden && "hidden md:flex"
     )}>
-      <div className="p-4 border-b border-[#d1d7db] bg-[#f0f2f5]">
+      <div className="p-4 border-b border-[#d1d7db] bg-[#f0f2f5] safe-area-top">
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">
             <h1 className="text-xl font-semibold text-[#111b21]">Chats</h1>

--- a/src/components/message-view.tsx
+++ b/src/components/message-view.tsx
@@ -315,7 +315,7 @@ export function MessageView({ conversationId, phoneNumber, contactName, onTempla
         "flex-1 flex flex-col bg-[#efeae2]",
         !isVisible && "hidden md:flex"
       )}>
-        <div className="p-3 border-b border-[#d1d7db] bg-[#f0f2f5]">
+        <div className="p-3 border-b border-[#d1d7db] bg-[#f0f2f5] safe-area-top">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2 flex-1">
               {onBack && (
@@ -341,7 +341,7 @@ export function MessageView({ conversationId, phoneNumber, contactName, onTempla
             {[1, 2, 3, 4, 5, 6].map((i) => (
               <div key={i} className={cn('flex mb-2', i % 2 === 0 ? 'justify-end' : 'justify-start')}>
                 <div className={cn(
-                  'max-w-[70%] rounded-lg px-3 py-2 shadow-sm',
+                  'max-w-[85%] md:max-w-[70%] rounded-lg px-3 py-2 shadow-sm',
                   i % 2 === 0 ? 'rounded-br-none' : 'rounded-bl-none'
                 )}>
                   <Skeleton className="h-4 mb-2" style={{ width: `${Math.random() * 150 + 150}px` }} />
@@ -360,7 +360,7 @@ export function MessageView({ conversationId, phoneNumber, contactName, onTempla
       "flex-1 flex flex-col bg-[#efeae2]",
       !isVisible && "hidden md:flex"
     )}>
-      <div className="p-3 border-b border-[#d1d7db] bg-[#f0f2f5]">
+      <div className="p-3 border-b border-[#d1d7db] bg-[#f0f2f5] safe-area-top">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2 flex-1 min-w-0">
             {onBack && (
@@ -419,7 +419,7 @@ export function MessageView({ conversationId, phoneNumber, contactName, onTempla
                 >
                   <div
                     className={cn(
-                      'max-w-[70%] rounded-lg px-3 py-2 relative shadow-sm',
+                      'max-w-[85%] md:max-w-[70%] rounded-lg px-3 py-2 relative shadow-sm',
                       message.direction === 'outbound'
                         ? 'bg-[#d9fdd3] text-[#111b21] rounded-br-none'
                         : 'bg-white text-[#111b21] rounded-bl-none'
@@ -534,7 +534,7 @@ export function MessageView({ conversationId, phoneNumber, contactName, onTempla
         </div>
       </ScrollArea>
 
-      <div className="border-t border-[#d1d7db] bg-[#f0f2f5]">
+      <div className="border-t border-[#d1d7db] bg-[#f0f2f5] safe-area-bottom">
         {canSendRegularMessage ? (
           <>
             {selectedFile && (


### PR DESCRIPTION
## Summary

Improves the mobile experience for the WhatsApp inbox on modern smartphones (especially iPhones with notch/dynamic island).

### Changes

- **`h-screen` → `h-dvh`** in the main layout container — `100vh` on mobile includes the browser chrome (address bar), causing the content to overflow. `dvh` (dynamic viewport height) adjusts to the actual visible area, which is critical when the virtual keyboard opens.
- **Viewport meta** with `viewport-fit: cover`, `maximumScale: 1`, `userScalable: false` — enables edge-to-edge rendering on notched iPhones and prevents accidental pinch-to-zoom.
- **Safe area insets** (`env(safe-area-inset-top)` / `env(safe-area-inset-bottom)`) — adds proper padding for the notch and home indicator on iPhone X+. Applied to conversation list header, chat header, and message input area.
- **`border-r` → `md:border-r`** on conversation list — removes unnecessary right border when the list is full-width on mobile.
- **Message bubble width** `max-w-[70%]` → `max-w-[85%] md:max-w-[70%]` — wider bubbles on narrow mobile screens for better readability.

### What's NOT changed

- Zero changes to business logic, API calls, or message handling
- Desktop experience is identical — all changes are behind `md:` breakpoints, safe area insets (which are 0px on desktop), or `dvh` (which equals `vh` on desktop)

### Testing

- Build passes cleanly (`next build`)
- Tested with Chrome DevTools responsive mode (iPhone 14 Pro, 393x852)
- 5 files changed, 29 insertions, 11 deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)