### PR TITLE
Add inbox phone number settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A WhatsApp Web-style inbox built with Next.js for the WhatsApp Cloud API. Send messages, templates, and interactive buttons with a familiar UI.
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fgokapso%2Fwhatsapp-cloud-inbox&env=PHONE_NUMBER_ID,KAPSO_API_KEY,WABA_ID&envDescription=Get%20these%20credentials%20from%20app.kapso.ai&envLink=https%3A%2F%2Fapp.kapso.ai)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fgokapso%2Fwhatsapp-cloud-inbox&env=KAPSO_API_KEY&envDescription=Get%20your%20Kapso%20API%20key%20from%20app.kapso.ai&envLink=https%3A%2F%2Fapp.kapso.ai)
 
 ![WhatsApp Cloud Inbox](https://cdn.jsdelivr.net/gh/gokapso/whatsapp-cloud-inbox@main/assets/kapso-whatsapp-inbox.png)
 
@@ -22,10 +22,7 @@ A WhatsApp Web-style inbox built with Next.js for the WhatsApp Cloud API. Send m
 
 1. Create account at [app.kapso.ai](https://app.kapso.ai)
 2. Connect a WhatsApp number
-3. Get your credentials:
-   - `PHONE_NUMBER_ID`
-   - `KAPSO_API_KEY`
-   - `WABA_ID`
+3. Get your Kapso API key
 
 ### 2. Clone and install
 
@@ -40,10 +37,15 @@ npm install
 Create `.env`:
 
 ```env
-PHONE_NUMBER_ID=your_phone_number_id
 KAPSO_API_KEY=your_kapso_api_key
-WABA_ID=your_business_account_id
 WHATSAPP_API_URL=https://api.kapso.ai/meta/whatsapp  # Optional: custom API endpoint
+
+# Optional: only needed when your platform API is on a different host
+KAPSO_API_BASE_URL=https://api.kapso.ai
+
+# Optional: backwards-compatible single-number fallback
+PHONE_NUMBER_ID=your_phone_number_id
+WABA_ID=your_business_account_id
 ```
 
 ### 4. Run
@@ -53,6 +55,8 @@ npm run dev
 ```
 
 Open [http://localhost:4000](http://localhost:4000)
+
+Open [http://localhost:4000/settings](http://localhost:4000/settings) to choose which WhatsApp numbers the inbox tracks. The app discovers `PHONE_NUMBER_ID` and `WABA_ID` values from Kapso using `KAPSO_API_KEY`, then stores the selected numbers in an HTTP-only cookie.
 
 ## Key Features
 

--- a/src/app/api/conversations/route.ts
+++ b/src/app/api/conversations/route.ts
@@ -4,7 +4,9 @@ import {
   type ConversationKapsoExtensions,
   type ConversationRecord
 } from '@kapso/whatsapp-cloud-api';
-import { whatsappClient, PHONE_NUMBER_ID } from '@/lib/whatsapp-client';
+import { configurationErrorResponse, getTrackedPhoneNumbers } from '@/lib/inbox-settings';
+import { whatsappClient } from '@/lib/whatsapp-client';
+import type { KapsoPhoneNumber } from '@/types/settings';
 
 function parseDirection(kapso?: ConversationKapsoExtensions): 'inbound' | 'outbound' {
   if (!kapso) {
@@ -29,56 +31,91 @@ export async function GET(request: Request) {
     const status = searchParams.get('status');
     const parsedLimit = Number.parseInt(searchParams.get('limit') ?? '', 10);
     const limit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? Math.min(parsedLimit, 100) : 50;
+    const { phoneNumbers, settings } = await getTrackedPhoneNumbers();
+    const selectedPhoneNumbers = settings.selectedPhoneNumberIds
+      .map(phoneNumberId => phoneNumbers.find(number => number.phone_number_id === phoneNumberId))
+      .filter((number): number is KapsoPhoneNumber => Boolean(number));
 
-    const response = await whatsappClient.conversations.list({
-      phoneNumberId: PHONE_NUMBER_ID,
-      ...(status && { status: status as 'active' | 'ended' }),
-      limit,
-      fields: buildKapsoFields([
-        'contact_name',
-        'messages_count',
-        'last_message_type',
-        'last_message_text',
-        'last_inbound_at',
-        'last_outbound_at'
-      ])
-    });
+    if (selectedPhoneNumbers.length === 0) {
+      return NextResponse.json({
+        data: [],
+        paging: undefined
+      });
+    }
+
+    const fields = buildKapsoFields([
+      'contact_name',
+      'messages_count',
+      'last_message_type',
+      'last_message_text',
+      'last_inbound_at',
+      'last_outbound_at'
+    ]);
+
+    const responses = await Promise.allSettled(
+      selectedPhoneNumbers.map(async (sourcePhoneNumber) => {
+        const response = await whatsappClient.conversations.list({
+          phoneNumberId: sourcePhoneNumber.phone_number_id,
+          ...(status && { status: status as 'active' | 'ended' }),
+          limit,
+          fields
+        });
+
+        return {
+          sourcePhoneNumber,
+          response
+        };
+      })
+    );
+
+    const successfulResponses = responses.flatMap(result =>
+      result.status === 'fulfilled' ? [result.value] : []
+    );
+
+    if (successfulResponses.length === 0) {
+      const failedResponse = responses.find(result => result.status === 'rejected');
+      throw failedResponse?.reason ?? new Error('Failed to fetch conversations');
+    }
 
     // Transform conversations to match frontend expectations
-    const transformedData = response.data.map((conversation: ConversationRecord) => {
-      const kapso = conversation.kapso;
+    const transformedData = successfulResponses.flatMap(({ response, sourcePhoneNumber }) =>
+      response.data.map((conversation: ConversationRecord) => {
+        const kapso = conversation.kapso;
 
-      const lastMessageText = typeof kapso?.lastMessageText === 'string' ? kapso.lastMessageText : undefined;
-      const lastMessageType = typeof kapso?.lastMessageType === 'string' ? kapso.lastMessageType : undefined;
+        const lastMessageText = typeof kapso?.lastMessageText === 'string' ? kapso.lastMessageText : undefined;
+        const lastMessageType = typeof kapso?.lastMessageType === 'string' ? kapso.lastMessageType : undefined;
 
-      return {
-        id: conversation.id,
-        phoneNumber: conversation.phoneNumber ?? '',
-        status: conversation.status ?? 'unknown',
-        lastActiveAt: typeof conversation.lastActiveAt === 'string' ? conversation.lastActiveAt : undefined,
-        phoneNumberId: conversation.phoneNumberId ?? PHONE_NUMBER_ID,
-        metadata: conversation.metadata ?? {},
-        contactName: typeof kapso?.contactName === 'string' ? kapso.contactName : undefined,
-        messagesCount: typeof kapso?.messagesCount === 'number' ? kapso.messagesCount : undefined,
-        lastMessage: lastMessageText
-          ? {
-              content: lastMessageText,
-              direction: parseDirection(kapso),
-              type: lastMessageType
-            }
-          : undefined
-      };
-    });
+        return {
+          id: conversation.id,
+          phoneNumber: conversation.phoneNumber ?? '',
+          status: conversation.status ?? 'unknown',
+          lastActiveAt: typeof conversation.lastActiveAt === 'string' ? conversation.lastActiveAt : undefined,
+          phoneNumberId: conversation.phoneNumberId ?? sourcePhoneNumber.phone_number_id,
+          inboxPhoneNumber: sourcePhoneNumber.display_phone_number,
+          inboxDisplayName: sourcePhoneNumber.display_name ?? sourcePhoneNumber.verified_name ?? sourcePhoneNumber.name,
+          businessAccountId: sourcePhoneNumber.business_account_id,
+          metadata: conversation.metadata ?? {},
+          contactName: typeof kapso?.contactName === 'string' ? kapso.contactName : undefined,
+          messagesCount: typeof kapso?.messagesCount === 'number' ? kapso.messagesCount : undefined,
+          lastMessage: lastMessageText
+            ? {
+                content: lastMessageText,
+                direction: parseDirection(kapso),
+                type: lastMessageType
+              }
+            : undefined
+        };
+      })
+    );
 
     return NextResponse.json({
       data: transformedData,
-      paging: response.paging
+      partialErrors: responses
+        .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+        .map(result => result.reason instanceof Error ? result.reason.message : 'Failed to fetch conversations')
     });
   } catch (error) {
     console.error('Error fetching conversations:', error);
-    return NextResponse.json(
-      { error: 'Failed to fetch conversations' },
-      { status: 500 }
-    );
+    return configurationErrorResponse(error);
   }
 }

--- a/src/app/api/media/[mediaId]/route.ts
+++ b/src/app/api/media/[mediaId]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import { whatsappClient, PHONE_NUMBER_ID } from '@/lib/whatsapp-client';
+import { configurationErrorResponse, resolvePhoneNumberContext } from '@/lib/inbox-settings';
+import { whatsappClient } from '@/lib/whatsapp-client';
 
 export async function GET(
   request: Request,
@@ -7,15 +8,19 @@ export async function GET(
 ) {
   const { mediaId } = await params;
   try {
+    const { searchParams } = new URL(request.url);
+    const configuredPhoneNumber = await resolvePhoneNumberContext(searchParams.get('phoneNumberId') ?? undefined);
+    const phoneNumberId = configuredPhoneNumber.phone_number_id;
+
     // Get metadata for mime type
     const metadata = await whatsappClient.media.get({
       mediaId,
-      phoneNumberId: PHONE_NUMBER_ID
+      phoneNumberId
     });
 
     const buffer = await whatsappClient.media.download({
       mediaId,
-      phoneNumberId: PHONE_NUMBER_ID,
+      phoneNumberId,
       auth: 'never' // Force no auth headers for CDN
     });
 
@@ -31,13 +36,7 @@ export async function GET(
       }
     });
   } catch (error) {
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch media',
-        details: error instanceof Error ? error.message : 'Unknown error',
-        mediaId
-      },
-      { status: 500 }
-    );
+    console.error('Error fetching media:', error);
+    return configurationErrorResponse(error);
   }
 }

--- a/src/app/api/messages/[conversationId]/route.ts
+++ b/src/app/api/messages/[conversationId]/route.ts
@@ -5,7 +5,8 @@ import {
   type MediaData,
   type MetaMessage
 } from '@kapso/whatsapp-cloud-api';
-import { whatsappClient, PHONE_NUMBER_ID } from '@/lib/whatsapp-client';
+import { configurationErrorResponse, resolvePhoneNumberContext } from '@/lib/inbox-settings';
+import { whatsappClient } from '@/lib/whatsapp-client';
 
 type MessageTypeData = {
   filename?: string;
@@ -74,6 +75,46 @@ function extractMediaData(mediaData: MediaData | undefined): Pick<MediaData, 'fi
   };
 }
 
+function isGeneratedMediaAttachmentContent(content: string, mediaUrl?: string): boolean {
+  const trimmedContent = content.trim();
+  if (!trimmedContent) return false;
+  if (mediaUrl && trimmedContent === mediaUrl.trim()) return true;
+  if (/^https?:\/\//i.test(trimmedContent)) return true;
+  if (/\bURL:\s*https?:\/\//i.test(trimmedContent)) return true;
+  return /^(image|audio)\s+attached\b/i.test(trimmedContent);
+}
+
+function extractTranscriptContent(content: string): string | undefined {
+  const match = content.match(/\bTranscript:\s*[\s\S]*$/i);
+  if (!match) return undefined;
+
+  return match[0]
+    .replace(/\s+\bURL:\s*https?:\/\/\S+[\s\S]*$/i, '')
+    .trim();
+}
+
+function normalizeMessageContent(input: {
+  content?: string;
+  messageType: string;
+  mediaUrl?: string;
+}): string {
+  if (!input.content) return '';
+
+  if (input.messageType === 'audio') {
+    return extractTranscriptContent(input.content) ??
+      (isGeneratedMediaAttachmentContent(input.content, input.mediaUrl) ? '' : input.content);
+  }
+
+  if (
+    input.messageType === 'image' &&
+    isGeneratedMediaAttachmentContent(input.content, input.mediaUrl)
+  ) {
+    return '';
+  }
+
+  return input.content;
+}
+
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ conversationId: string }> }
@@ -83,9 +124,11 @@ export async function GET(
     const { searchParams } = new URL(request.url);
     const parsedLimit = Number.parseInt(searchParams.get('limit') ?? '', 10);
     const limit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? Math.min(parsedLimit, 100) : 50;
+    const phoneNumber = await resolvePhoneNumberContext(searchParams.get('phoneNumberId') ?? undefined);
+    const phoneNumberId = phoneNumber.phone_number_id;
 
     const response = await whatsappClient.messages.listByConversation({
-      phoneNumberId: PHONE_NUMBER_ID,
+      phoneNumberId,
       conversationId,
       limit,
       fields: buildKapsoFields([
@@ -148,6 +191,11 @@ export async function GET(
       const kapsoContent = normaliseKapsoContent(kapsoExtensions?.content);
       const textBody = typeof text?.body === 'string' ? text.body : undefined;
       const reactionEmoji = typeof reaction?.emoji === 'string' ? reaction.emoji : undefined;
+      const content = normalizeMessageContent({
+        content: kapsoContent ?? textBody ?? reactionEmoji,
+        messageType: msg.type,
+        mediaUrl
+      });
 
       const fallbackCaption =
         (typeof image?.caption === 'string' && image.caption) ||
@@ -159,8 +207,9 @@ export async function GET(
 
       return {
         id: msg.id,
+        phoneNumberId,
         direction: typeof kapsoExtensions?.direction === 'string' ? kapsoExtensions.direction : 'inbound',
-        content: kapsoContent ?? textBody ?? reactionEmoji ?? fallbackCaption ?? '',
+        content,
         createdAt: toIsoString(msg.timestamp, lastMessageTimestamp),
         status: typeof kapsoExtensions?.status === 'string' ? kapsoExtensions.status : undefined,
         phoneNumber: typeof kapsoExtensions?.phoneNumber === 'string' ? kapsoExtensions.phoneNumber : msg.from,
@@ -186,9 +235,9 @@ export async function GET(
     });
   } catch (error) {
     console.error('Error fetching messages:', error);
-    return NextResponse.json(
-      { error: 'Failed to fetch messages', conversationId },
-      { status: 500 }
-    );
+    if (error instanceof Error) {
+      return configurationErrorResponse(error);
+    }
+    return NextResponse.json({ error: 'Failed to fetch messages', conversationId }, { status: 500 });
   }
 }

--- a/src/app/api/messages/interactive/route.ts
+++ b/src/app/api/messages/interactive/route.ts
@@ -1,10 +1,13 @@
 import { NextResponse } from 'next/server';
-import { whatsappClient, PHONE_NUMBER_ID } from '@/lib/whatsapp-client';
+import { configurationErrorResponse, resolvePhoneNumberContext } from '@/lib/inbox-settings';
+import { whatsappClient } from '@/lib/whatsapp-client';
 
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    const { phoneNumber, header, body: bodyText, buttons } = body;
+    const { phoneNumber, header, body: bodyText, buttons, phoneNumberId: requestedPhoneNumberId } = body;
+    const configuredPhoneNumber = await resolvePhoneNumberContext(requestedPhoneNumberId);
+    const phoneNumberId = configuredPhoneNumber.phone_number_id;
 
     if (!phoneNumber || !bodyText || !buttons || buttons.length === 0) {
       return NextResponse.json(
@@ -29,7 +32,7 @@ export async function POST(request: Request) {
       header?: { type: 'text'; text: string };
       buttons: Array<{ id: string; title: string }>;
     } = {
-      phoneNumberId: PHONE_NUMBER_ID,
+      phoneNumberId,
       to: phoneNumber,
       bodyText,
       buttons: buttons.map((btn: { id: string; title: string }) => ({
@@ -52,9 +55,6 @@ export async function POST(request: Request) {
     return NextResponse.json(result);
   } catch (error) {
     console.error('Error sending interactive message:', error);
-    return NextResponse.json(
-      { error: 'Failed to send interactive message' },
-      { status: 500 }
-    );
+    return configurationErrorResponse(error);
   }
 }

--- a/src/app/api/messages/send/route.ts
+++ b/src/app/api/messages/send/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import { whatsappClient, PHONE_NUMBER_ID } from '@/lib/whatsapp-client';
+import { configurationErrorResponse, resolvePhoneNumberContext } from '@/lib/inbox-settings';
+import { whatsappClient } from '@/lib/whatsapp-client';
 
 export async function POST(request: Request) {
   try {
@@ -7,6 +8,8 @@ export async function POST(request: Request) {
     const to = formData.get('to') as string;
     const body = formData.get('body') as string;
     const file = formData.get('file') as File | null;
+    const configuredPhoneNumber = await resolvePhoneNumberContext(formData.get('phoneNumberId') as string | undefined);
+    const phoneNumberId = configuredPhoneNumber.phone_number_id;
 
     if (!to) {
       return NextResponse.json(
@@ -24,7 +27,7 @@ export async function POST(request: Request) {
 
       // Upload media first
       const uploadResult = await whatsappClient.media.upload({
-        phoneNumberId: PHONE_NUMBER_ID,
+        phoneNumberId,
         type: mediaType as 'image' | 'video' | 'audio' | 'document',
         file: file,
         fileName: file.name
@@ -33,25 +36,25 @@ export async function POST(request: Request) {
       // Send message with media
       if (mediaType === 'image') {
         result = await whatsappClient.messages.sendImage({
-          phoneNumberId: PHONE_NUMBER_ID,
+          phoneNumberId,
           to,
           image: { id: uploadResult.id, caption: body || undefined }
         });
       } else if (mediaType === 'video') {
         result = await whatsappClient.messages.sendVideo({
-          phoneNumberId: PHONE_NUMBER_ID,
+          phoneNumberId,
           to,
           video: { id: uploadResult.id, caption: body || undefined }
         });
       } else if (mediaType === 'audio') {
         result = await whatsappClient.messages.sendAudio({
-          phoneNumberId: PHONE_NUMBER_ID,
+          phoneNumberId,
           to,
           audio: { id: uploadResult.id }
         });
       } else {
         result = await whatsappClient.messages.sendDocument({
-          phoneNumberId: PHONE_NUMBER_ID,
+          phoneNumberId,
           to,
           document: { id: uploadResult.id, caption: body || undefined, filename: file.name }
         });
@@ -59,7 +62,7 @@ export async function POST(request: Request) {
     } else if (body) {
       // Send text message
       result = await whatsappClient.messages.sendText({
-        phoneNumberId: PHONE_NUMBER_ID,
+        phoneNumberId,
         to,
         body
       });
@@ -73,9 +76,6 @@ export async function POST(request: Request) {
     return NextResponse.json(result);
   } catch (error) {
     console.error('Error sending message:', error);
-    return NextResponse.json(
-      { error: 'Failed to send message' },
-      { status: 500 }
-    );
+    return configurationErrorResponse(error);
   }
 }

--- a/src/app/api/phone-numbers/route.ts
+++ b/src/app/api/phone-numbers/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import {
+  configurationErrorResponse,
+  getAvailablePhoneNumbers
+} from '@/lib/inbox-settings';
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const force = searchParams.get('refresh') === 'true';
+    const phoneNumbers = await getAvailablePhoneNumbers({ force });
+
+    return NextResponse.json({
+      data: phoneNumbers
+    });
+  } catch (error) {
+    console.error('Error fetching phone numbers:', error);
+    return configurationErrorResponse(error);
+  }
+}

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server';
+import {
+  INBOX_SETTINGS_COOKIE,
+  configurationErrorResponse,
+  getAvailablePhoneNumbers,
+  getTrackedPhoneNumbers,
+  readStoredInboxSettings,
+  sanitizeInboxSettings,
+  serializeInboxSettings
+} from '@/lib/inbox-settings';
+import type { InboxSettings } from '@/types/settings';
+
+const SETTINGS_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const force = searchParams.get('refresh') === 'true';
+    const [phoneNumbers, storedSettings] = await Promise.all([
+      getAvailablePhoneNumbers({ force }),
+      readStoredInboxSettings()
+    ]);
+    const settings = sanitizeInboxSettings(storedSettings, phoneNumbers);
+
+    return NextResponse.json({
+      phoneNumbers,
+      selectedPhoneNumberIds: settings.selectedPhoneNumberIds,
+      defaultPhoneNumberId: settings.defaultPhoneNumberId,
+      hasStoredSettings: Boolean(storedSettings)
+    });
+  } catch (error) {
+    console.error('Error fetching inbox settings:', error);
+    return configurationErrorResponse(error);
+  }
+}
+
+export async function PUT(request: Request) {
+  try {
+    const body = await request.json() as Partial<InboxSettings>;
+    const { phoneNumbers } = await getTrackedPhoneNumbers();
+    const settings = sanitizeInboxSettings(
+      {
+        selectedPhoneNumberIds: Array.isArray(body.selectedPhoneNumberIds)
+          ? body.selectedPhoneNumberIds
+          : [],
+        ...(typeof body.defaultPhoneNumberId === 'string' && {
+          defaultPhoneNumberId: body.defaultPhoneNumberId
+        })
+      },
+      phoneNumbers
+    );
+
+    const response = NextResponse.json({
+      phoneNumbers,
+      selectedPhoneNumberIds: settings.selectedPhoneNumberIds,
+      defaultPhoneNumberId: settings.defaultPhoneNumberId,
+      hasStoredSettings: true
+    });
+
+    response.cookies.set(INBOX_SETTINGS_COOKIE, serializeInboxSettings(settings), {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      path: '/',
+      maxAge: SETTINGS_COOKIE_MAX_AGE_SECONDS
+    });
+
+    return response;
+  } catch (error) {
+    console.error('Error saving inbox settings:', error);
+    return configurationErrorResponse(error);
+  }
+}

--- a/src/app/api/templates/route.ts
+++ b/src/app/api/templates/route.ts
@@ -1,9 +1,12 @@
 import { NextResponse } from 'next/server';
+import { configurationErrorResponse, resolvePhoneNumberContext } from '@/lib/inbox-settings';
 import { whatsappClient } from '@/lib/whatsapp-client';
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
-    const wabaId = process.env.WABA_ID;
+    const { searchParams } = new URL(request.url);
+    const phoneNumber = await resolvePhoneNumberContext(searchParams.get('phoneNumberId') ?? undefined);
+    const wabaId = phoneNumber.business_account_id || process.env.WABA_ID;
 
     if (!wabaId) {
       return NextResponse.json(
@@ -23,9 +26,6 @@ export async function GET() {
     });
   } catch (error) {
     console.error('Error fetching templates:', error);
-    return NextResponse.json(
-      { error: 'Failed to fetch templates' },
-      { status: 500 }
-    );
+    return configurationErrorResponse(error);
   }
 }

--- a/src/app/api/templates/send/route.ts
+++ b/src/app/api/templates/send/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { buildTemplateSendPayload } from '@kapso/whatsapp-cloud-api';
-import { whatsappClient, PHONE_NUMBER_ID } from '@/lib/whatsapp-client';
+import { configurationErrorResponse, resolvePhoneNumberContext } from '@/lib/inbox-settings';
+import { whatsappClient } from '@/lib/whatsapp-client';
 import type { TemplateParameterInfo } from '@/types/whatsapp';
 
 type TemplateSendInput = Parameters<typeof buildTemplateSendPayload>[0];
@@ -14,7 +15,9 @@ type ButtonTextParameter = { type: 'text'; text: string; parameter_name?: string
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    const { to, templateName, languageCode, parameters, parameterInfo } = body;
+    const { to, templateName, languageCode, parameters, parameterInfo, phoneNumberId: requestedPhoneNumberId } = body;
+    const phoneNumber = await resolvePhoneNumberContext(requestedPhoneNumberId);
+    const phoneNumberId = phoneNumber.phone_number_id;
 
     if (!to || !templateName || !languageCode) {
       return NextResponse.json(
@@ -110,7 +113,7 @@ export async function POST(request: Request) {
 
     // Send template message
     const result = await whatsappClient.messages.sendTemplate({
-      phoneNumberId: PHONE_NUMBER_ID,
+      phoneNumberId,
       to,
       template: templatePayload
     });
@@ -118,9 +121,6 @@ export async function POST(request: Request) {
     return NextResponse.json(result);
   } catch (error) {
     console.error('Error sending template:', error);
-    return NextResponse.json(
-      { error: 'Failed to send template message' },
-      { status: 500 }
-    );
+    return configurationErrorResponse(error);
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,7 +33,7 @@ export default function Home() {
     setSelectedThreadKey(thread.key);
   };
 
-  const handleTemplateSent = async (phoneNumber: string) => {
+  const handleTemplateSent = async (phoneNumber: string, phoneNumberId?: string) => {
     const refreshedConversations = await queryClient.fetchQuery({
       queryKey: CONVERSATIONS_QUERY_KEY,
       queryFn: fetchConversations,
@@ -41,9 +41,12 @@ export default function Home() {
     });
     const phoneNumberKey = phoneNumber.replace(/\D/g, '') || phoneNumber;
     const refreshedThread = groupConversationsByPhoneNumber(refreshedConversations)
-      .find(thread => thread.key === phoneNumberKey || thread.phoneNumber === phoneNumber);
+      .find(thread =>
+        (!phoneNumberId || thread.phoneNumberId === phoneNumberId) &&
+        (thread.key.endsWith(`:${phoneNumberKey}`) || thread.phoneNumber === phoneNumber)
+      );
 
-    setSelectedThreadKey(refreshedThread?.key ?? phoneNumberKey);
+    setSelectedThreadKey(refreshedThread?.key ?? (phoneNumberId ? `${phoneNumberId}:${phoneNumberKey}` : phoneNumberKey));
   };
 
   const handleBackToList = () => {
@@ -61,6 +64,9 @@ export default function Home() {
         conversationId={selectedThread?.latestConversation.id}
         conversations={selectedThread?.conversations || []}
         phoneNumber={selectedThread?.phoneNumber}
+        phoneNumberId={selectedThread?.phoneNumberId}
+        inboxPhoneNumber={selectedThread?.inboxPhoneNumber}
+        inboxDisplayName={selectedThread?.inboxDisplayName}
         contactName={selectedThread?.contactName}
         lastActiveAt={selectedThread?.lastActiveAt}
         onTemplateSent={handleTemplateSent}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,393 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  ArrowLeft,
+  Building2,
+  Check,
+  Loader2,
+  RefreshCw,
+  Save,
+  Settings,
+  Smartphone
+} from 'lucide-react';
+import { CONVERSATIONS_QUERY_KEY } from '@/lib/inbox-data';
+import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import { ThemeToggle } from '@/components/theme-toggle';
+import type { InboxSettingsResponse, KapsoPhoneNumber } from '@/types/settings';
+
+const SETTINGS_QUERY_KEY = ['inbox-settings'] as const;
+
+async function fetchInboxSettings(refresh = false): Promise<InboxSettingsResponse> {
+  const response = await fetch(`/api/settings${refresh ? '?refresh=true' : ''}`);
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error(data.error || 'Failed to load settings');
+  }
+
+  return data;
+}
+
+function displayNameForPhoneNumber(phoneNumber: KapsoPhoneNumber): string {
+  return (
+    phoneNumber.display_name ||
+    phoneNumber.verified_name ||
+    phoneNumber.name ||
+    phoneNumber.display_phone_number ||
+    phoneNumber.phone_number_id
+  );
+}
+
+function groupPhoneNumbersByWaba(phoneNumbers: KapsoPhoneNumber[]) {
+  const groups = new Map<string, KapsoPhoneNumber[]>();
+
+  phoneNumbers.forEach((phoneNumber) => {
+    const key = phoneNumber.business_account_id || 'Unassigned WABA';
+    const existing = groups.get(key) ?? [];
+    existing.push(phoneNumber);
+    groups.set(key, existing);
+  });
+
+  return Array.from(groups.entries()).map(([businessAccountId, numbers]) => ({
+    businessAccountId,
+    numbers
+  }));
+}
+
+function qualityClass(qualityRating?: string) {
+  switch (qualityRating) {
+    case 'GREEN':
+      return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300';
+    case 'YELLOW':
+      return 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300';
+    case 'RED':
+      return 'border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300';
+    default:
+      return 'border-[var(--chat-border-strong)] bg-[var(--chat-hover)] text-muted-foreground';
+  }
+}
+
+export default function SettingsPage() {
+  const queryClient = useQueryClient();
+  const [selectedPhoneNumberIds, setSelectedPhoneNumberIds] = useState<string[]>([]);
+  const [defaultPhoneNumberId, setDefaultPhoneNumberId] = useState<string>();
+  const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const {
+    data,
+    error,
+    isPending,
+    isFetching
+  } = useQuery({
+    queryKey: SETTINGS_QUERY_KEY,
+    queryFn: () => fetchInboxSettings(false),
+  });
+
+  useEffect(() => {
+    if (!data || dirty) return;
+
+    setSelectedPhoneNumberIds(data.selectedPhoneNumberIds);
+    setDefaultPhoneNumberId(data.defaultPhoneNumberId);
+  }, [data, dirty]);
+
+  const groups = useMemo(
+    () => groupPhoneNumbersByWaba(data?.phoneNumbers ?? []),
+    [data?.phoneNumbers],
+  );
+
+  const selectedIdSet = useMemo(
+    () => new Set(selectedPhoneNumberIds),
+    [selectedPhoneNumberIds],
+  );
+
+  const selectedCount = selectedPhoneNumberIds.length;
+
+  const handleTogglePhoneNumber = (phoneNumberId: string) => {
+    setSaveMessage(null);
+    setSaveError(null);
+    setDirty(true);
+
+    setSelectedPhoneNumberIds((currentIds) => {
+      const isSelected = currentIds.includes(phoneNumberId);
+      const nextIds = isSelected
+        ? currentIds.filter(id => id !== phoneNumberId)
+        : [...currentIds, phoneNumberId];
+
+      setDefaultPhoneNumberId((currentDefaultId) => {
+        if (!nextIds.length) return undefined;
+        if (!currentDefaultId || currentDefaultId === phoneNumberId && isSelected) {
+          return nextIds[0];
+        }
+        return currentDefaultId;
+      });
+
+      return nextIds;
+    });
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaveMessage(null);
+    setSaveError(null);
+
+    try {
+      const response = await fetch('/api/settings', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          selectedPhoneNumberIds,
+          defaultPhoneNumberId
+        })
+      });
+      const payload = await response.json();
+
+      if (!response.ok) {
+        throw new Error(payload.error || 'Failed to save settings');
+      }
+
+      queryClient.setQueryData(SETTINGS_QUERY_KEY, payload);
+      await queryClient.invalidateQueries({ queryKey: CONVERSATIONS_QUERY_KEY });
+      setDirty(false);
+      setSaveMessage('Saved');
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to save settings');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    setSaveMessage(null);
+    setSaveError(null);
+
+    try {
+      const refreshedSettings = await fetchInboxSettings(true);
+      queryClient.setQueryData(SETTINGS_QUERY_KEY, refreshedSettings);
+      setSelectedPhoneNumberIds(refreshedSettings.selectedPhoneNumberIds);
+      setDefaultPhoneNumberId(refreshedSettings.defaultPhoneNumberId);
+      setDirty(false);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to refresh numbers');
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  return (
+    <div className="h-dvh min-h-dvh overflow-y-auto bg-background text-foreground">
+      <header className="sticky top-0 z-20 border-b border-[var(--chat-border-strong)] bg-[var(--chat-toolbar)] px-4 py-3 safe-area-top">
+        <div className="mx-auto flex max-w-5xl items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <Button
+              asChild
+              variant="ghost"
+              size="icon"
+              className="size-10 flex-shrink-0 rounded-md text-muted-foreground hover:bg-[var(--chat-hover)]"
+              aria-label="Back to inbox"
+              title="Back to inbox"
+            >
+              <Link href="/">
+                <ArrowLeft className="size-4" />
+              </Link>
+            </Button>
+            <div className="flex min-w-0 items-center gap-2">
+              <Settings className="size-4 flex-shrink-0 text-[var(--chat-presence)]" />
+              <h1 className="truncate text-base font-semibold">Inbox settings</h1>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <ThemeToggle className="size-10 rounded-md text-muted-foreground" />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleRefresh}
+              disabled={refreshing || saving}
+              className="h-10 rounded-md"
+            >
+              {refreshing ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <RefreshCw className="size-4" />
+              )}
+              <span className="hidden sm:inline">Refresh</span>
+            </Button>
+            <Button
+              type="button"
+              onClick={handleSave}
+              disabled={!dirty || saving || refreshing}
+              className="h-10 rounded-md bg-primary hover:bg-[var(--primary-hover)]"
+            >
+              {saving ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Save className="size-4" />
+              )}
+              <span>Save</span>
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-5xl px-4 py-5">
+        <section className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-sm font-semibold">Tracked numbers</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {selectedCount} selected
+              {data?.phoneNumbers.length ? ` of ${data.phoneNumbers.length}` : ''}
+            </p>
+          </div>
+          <div className="flex min-h-6 items-center gap-2 text-sm">
+            {isFetching && !refreshing && (
+              <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+                <Loader2 className="size-3.5 animate-spin" />
+                Syncing
+              </span>
+            )}
+            {saveMessage && (
+              <span className="inline-flex items-center gap-1.5 text-[var(--chat-presence)]">
+                <Check className="size-3.5" />
+                {saveMessage}
+              </span>
+            )}
+          </div>
+        </section>
+
+        {saveError && (
+          <div className="mb-4 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {saveError}
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {error instanceof Error ? error.message : 'Failed to load settings'}
+          </div>
+        )}
+
+        {isPending ? (
+          <div className="flex h-60 items-center justify-center text-muted-foreground">
+            <Loader2 className="size-6 animate-spin" />
+          </div>
+        ) : groups.length === 0 ? (
+          <div className="rounded-md border border-[var(--chat-border-strong)] bg-[var(--chat-surface)] px-4 py-8 text-center text-sm text-muted-foreground">
+            No WhatsApp numbers found.
+          </div>
+        ) : (
+          <div className="space-y-6 pb-8">
+            {groups.map((group) => (
+              <section key={group.businessAccountId} className="space-y-3">
+                <div className="flex min-w-0 items-center gap-2">
+                  <Building2 className="size-4 flex-shrink-0 text-muted-foreground" />
+                  <h3 className="truncate text-sm font-semibold">
+                    {group.businessAccountId}
+                  </h3>
+                  <Badge variant="outline" className="rounded-md">
+                    {group.numbers.length}
+                  </Badge>
+                </div>
+
+                <div className="grid gap-2">
+                  {group.numbers.map((phoneNumber) => {
+                    const phoneNumberId = phoneNumber.phone_number_id;
+                    const selected = selectedIdSet.has(phoneNumberId);
+                    const isDefault = defaultPhoneNumberId === phoneNumberId;
+
+                    return (
+                      <div
+                        key={phoneNumberId}
+                        className={cn(
+                          'grid gap-3 rounded-md border border-[var(--chat-border-strong)] bg-[var(--chat-surface)] p-3 transition-colors sm:grid-cols-[minmax(0,1fr)_auto]',
+                          selected && 'border-primary/50 bg-primary/5'
+                        )}
+                      >
+                        <label className="flex min-w-0 cursor-pointer items-start gap-3">
+                          <input
+                            type="checkbox"
+                            checked={selected}
+                            onChange={() => handleTogglePhoneNumber(phoneNumberId)}
+                            className="mt-1 size-4 rounded border-[var(--chat-border-strong)] accent-primary"
+                            aria-label={`Track ${displayNameForPhoneNumber(phoneNumber)}`}
+                          />
+                          <span className="min-w-0 flex-1">
+                            <span className="flex min-w-0 flex-wrap items-center gap-2">
+                              <span className="truncate text-sm font-semibold">
+                                {displayNameForPhoneNumber(phoneNumber)}
+                              </span>
+                              {phoneNumber.status && (
+                                <Badge variant="outline" className="rounded-md">
+                                  {phoneNumber.status}
+                                </Badge>
+                              )}
+                              {phoneNumber.quality_rating && (
+                                <Badge variant="outline" className={cn('rounded-md', qualityClass(phoneNumber.quality_rating))}>
+                                  {phoneNumber.quality_rating}
+                                </Badge>
+                              )}
+                            </span>
+                            <span className="mt-1 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                              <span className="inline-flex items-center gap-1">
+                                <Smartphone className="size-3.5" />
+                                {phoneNumber.display_phone_number || phoneNumberId}
+                              </span>
+                              <span className="font-mono">{phoneNumberId}</span>
+                              {phoneNumber.inbound_processing_enabled === false && (
+                                <span>Inbound off</span>
+                              )}
+                            </span>
+                          </span>
+                        </label>
+
+                        <div className="flex items-center justify-between gap-3 sm:justify-end">
+                          <label
+                            className={cn(
+                              'inline-flex h-9 cursor-pointer items-center gap-2 rounded-md border border-[var(--chat-border-strong)] px-3 text-xs font-medium text-muted-foreground',
+                              selected && 'text-foreground',
+                              isDefault && 'border-primary/50 bg-primary/10 text-foreground',
+                              !selected && 'cursor-not-allowed opacity-50'
+                            )}
+                          >
+                            <input
+                              type="radio"
+                              name="defaultPhoneNumberId"
+                              checked={isDefault}
+                              disabled={!selected}
+                              onChange={() => {
+                                setDirty(true);
+                                setSaveMessage(null);
+                                setSaveError(null);
+                                setDefaultPhoneNumberId(phoneNumberId);
+                              }}
+                              className="size-3.5 accent-primary"
+                              aria-label={`Use ${displayNameForPhoneNumber(phoneNumber)} as default sender`}
+                            />
+                            Default
+                          </label>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+
+                <Separator />
+              </section>
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/components/conversation-list.tsx
+++ b/src/components/conversation-list.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
 import { differenceInDays, differenceInHours, differenceInMinutes, format, isValid, isYesterday } from 'date-fns';
-import { BellOff, Check, ChevronDown, Plus, RefreshCw, Search } from 'lucide-react';
+import { BellOff, Check, ChevronDown, Plus, RefreshCw, Search, Settings } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
   CONVERSATIONS_QUERY_KEY,
@@ -226,6 +227,18 @@ export function ConversationList({ onSelectThread, selectedThreadKey, isHidden =
                 <BellOff className="size-4" />
               )}
             </Button>
+            <Button
+              asChild
+              variant="ghost"
+              size="icon"
+              className="size-8 rounded-md text-muted-foreground hover:bg-[var(--chat-icon-hover)] hover:text-foreground"
+              aria-label="Inbox settings"
+              title="Inbox settings"
+            >
+              <Link href="/settings">
+                <Settings className="size-4" />
+              </Link>
+            </Button>
             <ThemeToggle className="size-8 rounded-md text-muted-foreground md:size-8" />
           </div>
         </div>
@@ -376,6 +389,8 @@ export function ConversationList({ onSelectThread, selectedThreadKey, isHidden =
                       )}
                       <p className="truncate text-[11px] leading-4 text-muted-foreground/80">
                         {thread.phoneNumber}
+                        {(thread.inboxDisplayName || thread.inboxPhoneNumber) &&
+                          ` · via ${thread.inboxDisplayName || thread.inboxPhoneNumber}`}
                         {thread.conversationCount > 1 && ` · ${thread.conversationCount} conversations`}
                       </p>
                     </div>

--- a/src/components/interactive-message-dialog.tsx
+++ b/src/components/interactive-message-dialog.tsx
@@ -25,6 +25,7 @@ type Props = {
   onOpenChange: (open: boolean) => void;
   conversationId?: string;
   phoneNumber?: string;
+  phoneNumberId?: string;
   onMessageSent?: () => void;
 };
 
@@ -33,6 +34,7 @@ export function InteractiveMessageDialog({
   onOpenChange,
   conversationId,
   phoneNumber,
+  phoneNumberId,
   onMessageSent,
 }: Props) {
   const [header, setHeader] = useState('');
@@ -102,6 +104,7 @@ export function InteractiveMessageDialog({
         body: JSON.stringify({
           conversationId,
           phoneNumber,
+          phoneNumberId,
           header: header.trim() || undefined,
           body: body.trim(),
           buttons: buttons.map(btn => ({

--- a/src/components/media-message.tsx
+++ b/src/components/media-message.tsx
@@ -7,13 +7,14 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 type Props = {
   mediaId: string;
+  phoneNumberId?: string;
   messageType: string;
   caption?: string | null;
   filename?: string | null;
   isOutbound?: boolean;
 };
 
-export function MediaMessage({ mediaId, messageType, caption, filename, isOutbound }: Props) {
+export function MediaMessage({ mediaId, phoneNumberId, messageType, caption, filename, isOutbound }: Props) {
   const [mediaUrl, setMediaUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadFailed, setLoadFailed] = useState(false);
@@ -24,10 +25,14 @@ export function MediaMessage({ mediaId, messageType, caption, filename, isOutbou
 
   useEffect(() => {
     // Set the media URL to point to our proxy endpoint
-    setMediaUrl(`/api/media/${mediaId}`);
+    const params = new URLSearchParams();
+    if (phoneNumberId) {
+      params.set('phoneNumberId', phoneNumberId);
+    }
+    setMediaUrl(`/api/media/${mediaId}${params.size ? `?${params.toString()}` : ''}`);
     setLoading(false);
     setLoadFailed(false);
-  }, [mediaId]);
+  }, [mediaId, phoneNumberId]);
 
   if (loading) {
     return (

--- a/src/components/message-view.tsx
+++ b/src/components/message-view.tsx
@@ -178,13 +178,55 @@ function getDisabledInputMessage(messages: Message[]): string {
 
 const MESSAGE_SKELETON_WIDTHS = [280, 180, 320, 210, 260, 170];
 
+function extractTranscriptDisplayContent(content: string): string | undefined {
+  const match = content.match(/\bTranscript:\s*[\s\S]*$/i);
+  if (!match) return undefined;
+
+  return match[0]
+    .replace(/\s+\bURL:\s*https?:\/\/\S+[\s\S]*$/i, '')
+    .trim();
+}
+
+function isGeneratedAttachmentDisplayContent(content: string): boolean {
+  return (
+    /^https?:\/\//i.test(content) ||
+    /\bURL:\s*https?:\/\//i.test(content) ||
+    /^(image|audio)\s+attached\b/i.test(content)
+  );
+}
+
+function getDisplayMessageContent(message: Message): string | null {
+  if (!message.content || message.content === "[Image attached]") {
+    return null;
+  }
+
+  const trimmedContent = message.content.trim();
+
+  if (message.messageType === 'audio') {
+    return extractTranscriptDisplayContent(trimmedContent) ??
+      (isGeneratedAttachmentDisplayContent(trimmedContent) ? null : trimmedContent);
+  }
+
+  if (
+    message.messageType === 'image' &&
+    isGeneratedAttachmentDisplayContent(trimmedContent)
+  ) {
+    return null;
+  }
+
+  return trimmedContent;
+}
+
 type Props = {
   conversationId?: string;
   conversations?: Conversation[];
   phoneNumber?: string;
+  phoneNumberId?: string;
+  inboxPhoneNumber?: string;
+  inboxDisplayName?: string;
   contactName?: string;
   lastActiveAt?: string;
-  onTemplateSent?: (phoneNumber: string) => Promise<void>;
+  onTemplateSent?: (phoneNumber: string, phoneNumberId?: string) => Promise<void>;
   onBack?: () => void;
   isVisible?: boolean;
 };
@@ -193,6 +235,9 @@ export function MessageView({
   conversationId,
   conversations = [],
   phoneNumber,
+  phoneNumberId,
+  inboxPhoneNumber,
+  inboxDisplayName,
   contactName,
   lastActiveAt,
   onTemplateSent,
@@ -215,6 +260,7 @@ export function MessageView({
   const queryClient = useQueryClient();
   const lastSeenText = formatLastSeen(lastActiveAt);
   const displayPhoneNumber = formatDisplayPhoneNumber(phoneNumber);
+  const displayInboxPhoneNumber = formatDisplayPhoneNumber(inboxPhoneNumber);
   const threadConversationIds = useMemo(() => {
     const conversationIds = conversations.map(
       (conversation) => conversation.id,
@@ -226,8 +272,8 @@ export function MessageView({
         : [];
   }, [conversationId, conversations]);
   const threadMessagesQueryKey = useMemo(
-    () => phoneThreadMessagesQueryKey(phoneNumber, threadConversationIds),
-    [phoneNumber, threadConversationIds],
+    () => phoneThreadMessagesQueryKey(phoneNumberId, phoneNumber, threadConversationIds),
+    [phoneNumberId, phoneNumber, threadConversationIds],
   );
   const threadKey = threadConversationIds.join(":");
   const initialScrollKey = `${conversationId ?? ""}:${threadKey}`;
@@ -278,7 +324,7 @@ export function MessageView({
     const latestConversationId = threadConversationIds[0];
     const messageBatches = await Promise.all(
       threadConversationIds.map((threadConversationId) => {
-        const queryKey = conversationMessagesQueryKey(threadConversationId);
+        const queryKey = conversationMessagesQueryKey(phoneNumberId, threadConversationId);
         const cachedMessages = queryClient.getQueryData<Message[]>(queryKey);
 
         if (cachedMessages && threadConversationId !== latestConversationId) {
@@ -287,14 +333,14 @@ export function MessageView({
 
         return queryClient.fetchQuery({
           queryKey,
-          queryFn: () => fetchConversationMessages(threadConversationId),
+          queryFn: () => fetchConversationMessages(threadConversationId, phoneNumberId),
           staleTime: 0,
         });
       }),
     );
 
     return normalizeMessages(messageBatches.flat());
-  }, [queryClient, threadConversationIds]);
+  }, [phoneNumberId, queryClient, threadConversationIds]);
 
   const { data: messages = [], isPending: loading } = useQuery({
     queryKey: threadMessagesQueryKey,
@@ -310,8 +356,8 @@ export function MessageView({
     const messageBatches = await Promise.all(
       threadConversationIds.map((threadConversationId) =>
         queryClient.fetchQuery({
-          queryKey: conversationMessagesQueryKey(threadConversationId),
-          queryFn: () => fetchConversationMessages(threadConversationId),
+          queryKey: conversationMessagesQueryKey(phoneNumberId, threadConversationId),
+          queryFn: () => fetchConversationMessages(threadConversationId, phoneNumberId),
           staleTime: 0,
         }),
       ),
@@ -321,7 +367,7 @@ export function MessageView({
       threadMessagesQueryKey,
       normalizeMessages(messageBatches.flat()),
     );
-  }, [queryClient, threadConversationIds, threadMessagesQueryKey]);
+  }, [phoneNumberId, queryClient, threadConversationIds, threadMessagesQueryKey]);
 
   useEffect(() => {
     if (isNearBottom) {
@@ -467,6 +513,9 @@ export function MessageView({
     try {
       const formData = new FormData();
       formData.append("to", phoneNumber);
+      if (phoneNumberId) {
+        formData.append("phoneNumberId", phoneNumberId);
+      }
       if (messageInput.trim()) {
         formData.append("body", messageInput);
       }
@@ -496,7 +545,7 @@ export function MessageView({
     await refreshCurrentThread();
 
     if (phoneNumber && onTemplateSent) {
-      await onTemplateSent(phoneNumber);
+      await onTemplateSent(phoneNumber, phoneNumberId);
     }
   };
 
@@ -610,6 +659,12 @@ export function MessageView({
                     : displayPhoneNumber}
                 </p>
               )}
+              {(inboxDisplayName || displayInboxPhoneNumber) && (
+                <p className="truncate text-[11px] text-muted-foreground/80">
+                  via {inboxDisplayName || displayInboxPhoneNumber}
+                  {inboxDisplayName && displayInboxPhoneNumber ? ` · ${displayInboxPhoneNumber}` : ''}
+                </p>
+              )}
             </div>
           </div>
           <div className="flex items-center gap-2">
@@ -651,6 +706,7 @@ export function MessageView({
                 message,
                 prevMessage,
               );
+              const displayMessageContent = getDisplayMessageContent(message);
 
               return (
                 <div
@@ -751,6 +807,7 @@ export function MessageView({
                         <div className="mb-2">
                           <MediaMessage
                             mediaId={message.metadata.mediaId}
+                            phoneNumberId={message.phoneNumberId || phoneNumberId}
                             messageType={message.messageType}
                             caption={message.caption}
                             filename={message.filename}
@@ -765,23 +822,16 @@ export function MessageView({
                         </p>
                       )}
 
-                      {message.content &&
-                        message.content !== "[Image attached]" && (
-                          <p className="text-sm break-words whitespace-pre-wrap">
-                            {message.content}
-                          </p>
-                        )}
+                      {displayMessageContent && (
+                        <p className="text-sm break-words whitespace-pre-wrap">
+                          {displayMessageContent}
+                        </p>
+                      )}
 
                       <div className="mt-1 flex flex-wrap items-center gap-1.5">
                         <span className="text-[11px] tabular-nums text-muted-foreground">
                           {formatMessageTime(message.createdAt)}
                         </span>
-
-                        {message.messageType && (
-                          <span className="text-[11px] text-muted-foreground opacity-60">
-                            &middot; {message.messageType}
-                          </span>
-                        )}
 
                         {message.direction === "outbound" && message.status && (
                           <>
@@ -939,6 +989,7 @@ export function MessageView({
         open={showTemplateDialog}
         onOpenChange={setShowTemplateDialog}
         phoneNumber={phoneNumber || ""}
+        phoneNumberId={phoneNumberId}
         onTemplateSent={handleTemplateSent}
       />
 
@@ -947,6 +998,7 @@ export function MessageView({
         onOpenChange={setShowInteractiveDialog}
         conversationId={conversationId}
         phoneNumber={phoneNumber}
+        phoneNumberId={phoneNumberId}
         onMessageSent={async () => {
           await queryClient.invalidateQueries({
             queryKey: CONVERSATIONS_QUERY_KEY,

--- a/src/components/template-parameters-dialog.tsx
+++ b/src/components/template-parameters-dialog.tsx
@@ -24,6 +24,7 @@ type Props = {
   template: Template;
   parameterInfo: TemplateParameterInfo;
   phoneNumber: string;
+  phoneNumberId?: string;
   onBack: () => void;
   onTemplateSent?: () => void;
 };
@@ -34,6 +35,7 @@ export function TemplateParametersDialog({
   template,
   parameterInfo,
   phoneNumber,
+  phoneNumberId,
   onBack,
   onTemplateSent,
 }: Props) {
@@ -69,6 +71,7 @@ export function TemplateParametersDialog({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           to: phoneNumber,
+          phoneNumberId,
           templateName: template.name,
           languageCode: template.language,
           parameters: formattedParameters,

--- a/src/components/template-selector-dialog.tsx
+++ b/src/components/template-selector-dialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Send, Loader2 } from 'lucide-react';
 import {
   Dialog,
@@ -21,10 +21,11 @@ type Props = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   phoneNumber: string;
+  phoneNumberId?: string;
   onTemplateSent?: () => void;
 };
 
-export function TemplateSelectorDialog({ open, onOpenChange, phoneNumber, onTemplateSent }: Props) {
+export function TemplateSelectorDialog({ open, onOpenChange, phoneNumber, phoneNumberId, onTemplateSent }: Props) {
   const [templates, setTemplates] = useState<Template[]>([]);
   const [loading, setLoading] = useState(false);
   const [sending, setSending] = useState<string | null>(null);
@@ -35,17 +36,16 @@ export function TemplateSelectorDialog({ open, onOpenChange, phoneNumber, onTemp
   const [selectedTemplate, setSelectedTemplate] = useState<Template | null>(null);
   const [parameterInfo, setParameterInfo] = useState<TemplateParameterInfo | null>(null);
 
-  useEffect(() => {
-    if (open) {
-      fetchTemplates();
-    }
-  }, [open]);
-
-  const fetchTemplates = async () => {
+  const fetchTemplates = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch('/api/templates');
+      const params = new URLSearchParams();
+      if (phoneNumberId) {
+        params.set('phoneNumberId', phoneNumberId);
+      }
+
+      const response = await fetch(`/api/templates${params.size ? `?${params.toString()}` : ''}`);
       const data = await response.json();
 
       if (!response.ok) {
@@ -63,7 +63,13 @@ export function TemplateSelectorDialog({ open, onOpenChange, phoneNumber, onTemp
     } finally {
       setLoading(false);
     }
-  };
+  }, [phoneNumberId]);
+
+  useEffect(() => {
+    if (open) {
+      fetchTemplates();
+    }
+  }, [fetchTemplates, open]);
 
   const handleSelectTemplate = (template: Template) => {
     const params = getTemplateParameters(template);
@@ -89,6 +95,7 @@ export function TemplateSelectorDialog({ open, onOpenChange, phoneNumber, onTemp
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           to: phoneNumber,
+          phoneNumberId,
           templateName: template.name,
           languageCode: template.language
         })
@@ -222,6 +229,7 @@ export function TemplateSelectorDialog({ open, onOpenChange, phoneNumber, onTemp
         template={selectedTemplate}
         parameterInfo={parameterInfo}
         phoneNumber={phoneNumber}
+        phoneNumberId={phoneNumberId}
         onBack={handleBackToTemplateSelector}
         onTemplateSent={handleTemplateWithParametersSent}
       />

--- a/src/lib/inbox-data.ts
+++ b/src/lib/inbox-data.ts
@@ -8,6 +8,9 @@ export type Conversation = {
   status: string;
   lastActiveAt?: string;
   phoneNumberId: string;
+  inboxPhoneNumber?: string;
+  inboxDisplayName?: string;
+  businessAccountId?: string;
   metadata?: Record<string, unknown>;
   contactName?: string;
   messagesCount?: number;
@@ -21,6 +24,7 @@ export type Conversation = {
 export type Message = {
   id: string;
   conversationId: string;
+  phoneNumberId: string;
   direction: 'inbound' | 'outbound';
   content: string;
   createdAt: string;
@@ -47,6 +51,10 @@ export type Message = {
 export type ConversationThread = {
   key: string;
   phoneNumber: string;
+  phoneNumberId: string;
+  inboxPhoneNumber?: string;
+  inboxDisplayName?: string;
+  businessAccountId?: string;
   contactName?: string;
   conversations: Conversation[];
   latestConversation: Conversation;
@@ -59,12 +67,16 @@ export type ConversationThread = {
 
 export const CONVERSATIONS_QUERY_KEY = ['conversations'] as const;
 
-export function conversationMessagesQueryKey(conversationId: string) {
-  return ['conversation-messages', conversationId] as const;
+export function conversationMessagesQueryKey(phoneNumberId: string | undefined, conversationId: string) {
+  return ['conversation-messages', phoneNumberId ?? '', conversationId] as const;
 }
 
-export function phoneThreadMessagesQueryKey(phoneNumber: string | undefined, conversationIds: string[]) {
-  return ['phone-thread-messages', phoneNumber ?? '', conversationIds.join(':')] as const;
+export function phoneThreadMessagesQueryKey(
+  phoneNumberId: string | undefined,
+  phoneNumber: string | undefined,
+  conversationIds: string[]
+) {
+  return ['phone-thread-messages', phoneNumberId ?? '', phoneNumber ?? '', conversationIds.join(':')] as const;
 }
 
 function parseTimestamp(timestamp?: string): number {
@@ -76,7 +88,8 @@ function parseTimestamp(timestamp?: string): number {
 function conversationGroupKey(conversation: Conversation): string {
   const phoneNumber = conversation.phoneNumber.trim();
   const comparablePhoneNumber = phoneNumber.replace(/\D/g, '');
-  return comparablePhoneNumber || phoneNumber || `conversation:${conversation.id}`;
+  const contactKey = comparablePhoneNumber || phoneNumber || `conversation:${conversation.id}`;
+  return `${conversation.phoneNumberId}:${contactKey}`;
 }
 
 function byMostRecentConversation(a: Conversation, b: Conversation): number {
@@ -96,8 +109,13 @@ export async function fetchConversations(): Promise<Conversation[]> {
   return data.data || [];
 }
 
-export async function fetchConversationMessages(conversationId: string): Promise<Message[]> {
-  const response = await fetch(`/api/messages/${conversationId}?limit=100`);
+export async function fetchConversationMessages(conversationId: string, phoneNumberId?: string): Promise<Message[]> {
+  const params = new URLSearchParams({ limit: '100' });
+  if (phoneNumberId) {
+    params.set('phoneNumberId', phoneNumberId);
+  }
+
+  const response = await fetch(`/api/messages/${conversationId}?${params.toString()}`);
   const data = await response.json();
 
   if (!response.ok) {
@@ -106,6 +124,7 @@ export async function fetchConversationMessages(conversationId: string): Promise
 
   const messages = (data.data || []).map((message: Omit<Message, 'conversationId'>) => ({
     ...message,
+    phoneNumberId: message.phoneNumberId ?? phoneNumberId ?? '',
     conversationId,
   }));
 
@@ -130,6 +149,10 @@ export function groupConversationsByPhoneNumber(conversations: Conversation[]): 
       return {
         key,
         phoneNumber: latestConversation.phoneNumber,
+        phoneNumberId: latestConversation.phoneNumberId,
+        inboxPhoneNumber: latestConversation.inboxPhoneNumber,
+        inboxDisplayName: latestConversation.inboxDisplayName,
+        businessAccountId: latestConversation.businessAccountId,
         contactName: latestConversation.contactName || sortedConversations.find(conversation => conversation.contactName)?.contactName,
         conversations: sortedConversations,
         latestConversation,
@@ -159,6 +182,8 @@ export function filterConversationThreads(
 
     return (
       thread.phoneNumber.toLowerCase().includes(normalizedQuery) ||
+      thread.inboxPhoneNumber?.toLowerCase().includes(normalizedQuery) ||
+      thread.inboxDisplayName?.toLowerCase().includes(normalizedQuery) ||
       thread.contactName?.toLowerCase().includes(normalizedQuery) ||
       thread.conversations.some(conversation => conversation.id.toLowerCase().includes(normalizedQuery))
     );

--- a/src/lib/inbox-settings.ts
+++ b/src/lib/inbox-settings.ts
@@ -1,0 +1,273 @@
+import { cookies } from 'next/headers';
+import type { InboxSettings, KapsoPhoneNumber } from '@/types/settings';
+
+export const INBOX_SETTINGS_COOKIE = 'whatsapp-cloud-inbox-settings';
+
+const PHONE_NUMBERS_CACHE_TTL_MS = 60_000;
+
+type PlatformPhoneNumbersResponse = {
+  data?: KapsoPhoneNumber[];
+  meta?: {
+    page?: number;
+    per_page?: number;
+    total_pages?: number;
+    total_count?: number;
+  };
+};
+
+type PhoneNumbersCache = {
+  expiresAt: number;
+  data: KapsoPhoneNumber[];
+};
+
+let phoneNumbersCache: PhoneNumbersCache | null = null;
+
+export class InboxConfigurationError extends Error {
+  status: number;
+
+  constructor(message: string, status = 500) {
+    super(message);
+    this.name = 'InboxConfigurationError';
+    this.status = status;
+  }
+}
+
+function getKapsoApiBaseUrl(): string {
+  const explicitBaseUrl = process.env.KAPSO_API_BASE_URL || process.env.KAPSO_PLATFORM_API_URL;
+  if (explicitBaseUrl) {
+    return explicitBaseUrl.replace(/\/platform\/v1\/?$/, '').replace(/\/$/, '');
+  }
+
+  const whatsappApiUrl = process.env.WHATSAPP_API_URL;
+  if (whatsappApiUrl) {
+    try {
+      return new URL(whatsappApiUrl).origin;
+    } catch {
+      return 'https://api.kapso.ai';
+    }
+  }
+
+  return 'https://api.kapso.ai';
+}
+
+function platformApiUrl(path: string): string {
+  return `${getKapsoApiBaseUrl()}/platform/v1${path}`;
+}
+
+function getKapsoApiKey(): string {
+  const apiKey = process.env.KAPSO_API_KEY;
+  if (!apiKey) {
+    throw new InboxConfigurationError('KAPSO_API_KEY environment variable is not set', 500);
+  }
+  return apiKey;
+}
+
+function getEnvFallbackPhoneNumber(): KapsoPhoneNumber | null {
+  const phoneNumberId = process.env.PHONE_NUMBER_ID;
+  if (!phoneNumberId) return null;
+
+  return {
+    id: phoneNumberId,
+    phone_number_id: phoneNumberId,
+    business_account_id: process.env.WABA_ID,
+    display_name: 'Configured phone number',
+    status: 'CONNECTED'
+  };
+}
+
+function uniqueIds(ids: unknown): string[] {
+  if (!Array.isArray(ids)) return [];
+
+  return Array.from(
+    new Set(
+      ids
+        .filter((id): id is string => typeof id === 'string')
+        .map(id => id.trim())
+        .filter(Boolean)
+    )
+  );
+}
+
+function defaultSelectedPhoneNumberIds(phoneNumbers: KapsoPhoneNumber[]): string[] {
+  const envPhoneNumberId = process.env.PHONE_NUMBER_ID;
+  const availableIds = new Set(phoneNumbers.map(number => number.phone_number_id));
+
+  if (envPhoneNumberId && availableIds.has(envPhoneNumberId)) {
+    return [envPhoneNumberId];
+  }
+
+  const inboxReadyNumbers = phoneNumbers.filter(number =>
+    number.phone_number_id &&
+    number.status === 'CONNECTED' &&
+    number.inbound_processing_enabled !== false
+  );
+
+  if (inboxReadyNumbers.length > 0) {
+    return inboxReadyNumbers.map(number => number.phone_number_id);
+  }
+
+  return phoneNumbers
+    .map(number => number.phone_number_id)
+    .filter(Boolean);
+}
+
+export function sanitizeInboxSettings(
+  settings: InboxSettings | null,
+  phoneNumbers: KapsoPhoneNumber[]
+): InboxSettings {
+  const availableIds = new Set(phoneNumbers.map(number => number.phone_number_id));
+  const selectedPhoneNumberIds = settings
+    ? uniqueIds(settings.selectedPhoneNumberIds).filter(id => availableIds.has(id))
+    : defaultSelectedPhoneNumberIds(phoneNumbers);
+
+  const requestedDefaultPhoneNumberId = settings?.defaultPhoneNumberId?.trim();
+  const defaultPhoneNumberId =
+    requestedDefaultPhoneNumberId && selectedPhoneNumberIds.includes(requestedDefaultPhoneNumberId)
+      ? requestedDefaultPhoneNumberId
+      : selectedPhoneNumberIds[0];
+
+  return {
+    selectedPhoneNumberIds,
+    ...(defaultPhoneNumberId && { defaultPhoneNumberId })
+  };
+}
+
+export function serializeInboxSettings(settings: InboxSettings): string {
+  return encodeURIComponent(JSON.stringify(settings));
+}
+
+export function parseInboxSettingsCookie(value?: string): InboxSettings | null {
+  if (!value) return null;
+
+  try {
+    const parsed = JSON.parse(decodeURIComponent(value)) as Partial<InboxSettings>;
+    const selectedPhoneNumberIds = uniqueIds(parsed.selectedPhoneNumberIds);
+    const defaultPhoneNumberId =
+      typeof parsed.defaultPhoneNumberId === 'string' && parsed.defaultPhoneNumberId.trim()
+        ? parsed.defaultPhoneNumberId.trim()
+        : undefined;
+
+    return {
+      selectedPhoneNumberIds,
+      ...(defaultPhoneNumberId && { defaultPhoneNumberId })
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function readStoredInboxSettings(): Promise<InboxSettings | null> {
+  const cookieStore = await cookies();
+  return parseInboxSettingsCookie(cookieStore.get(INBOX_SETTINGS_COOKIE)?.value);
+}
+
+export async function fetchKapsoPhoneNumbers(options: { force?: boolean } = {}): Promise<KapsoPhoneNumber[]> {
+  if (!options.force && phoneNumbersCache && phoneNumbersCache.expiresAt > Date.now()) {
+    return phoneNumbersCache.data;
+  }
+
+  const apiKey = getKapsoApiKey();
+  const collectedPhoneNumbers: KapsoPhoneNumber[] = [];
+  let page = 1;
+  let totalPages = 1;
+
+  do {
+    const url = new URL(platformApiUrl('/whatsapp/phone_numbers'));
+    url.searchParams.set('page', String(page));
+    url.searchParams.set('per_page', '100');
+
+    const response = await fetch(url, {
+      headers: {
+        'X-API-Key': apiKey
+      },
+      cache: 'no-store'
+    });
+
+    if (!response.ok) {
+      const details = await response.text().catch(() => '');
+      throw new InboxConfigurationError(
+        details || `Failed to fetch WhatsApp phone numbers (${response.status})`,
+        response.status
+      );
+    }
+
+    const payload = await response.json() as PlatformPhoneNumbersResponse;
+    collectedPhoneNumbers.push(...(payload.data ?? []));
+
+    totalPages = payload.meta?.total_pages ?? 1;
+    page += 1;
+  } while (page <= totalPages);
+
+  phoneNumbersCache = {
+    expiresAt: Date.now() + PHONE_NUMBERS_CACHE_TTL_MS,
+    data: collectedPhoneNumbers
+  };
+
+  return collectedPhoneNumbers;
+}
+
+export async function getAvailablePhoneNumbers(options: { force?: boolean } = {}): Promise<KapsoPhoneNumber[]> {
+  try {
+    const phoneNumbers = await fetchKapsoPhoneNumbers(options);
+    if (phoneNumbers.length > 0) {
+      return phoneNumbers;
+    }
+  } catch (error) {
+    const fallback = getEnvFallbackPhoneNumber();
+    if (fallback) {
+      return [fallback];
+    }
+    throw error;
+  }
+
+  const fallback = getEnvFallbackPhoneNumber();
+  return fallback ? [fallback] : [];
+}
+
+export async function getTrackedPhoneNumbers(): Promise<{
+  phoneNumbers: KapsoPhoneNumber[];
+  settings: InboxSettings;
+  hasStoredSettings: boolean;
+}> {
+  const [phoneNumbers, storedSettings] = await Promise.all([
+    getAvailablePhoneNumbers(),
+    readStoredInboxSettings()
+  ]);
+  const settings = sanitizeInboxSettings(storedSettings, phoneNumbers);
+
+  return {
+    phoneNumbers,
+    settings,
+    hasStoredSettings: Boolean(storedSettings)
+  };
+}
+
+export async function resolvePhoneNumberContext(phoneNumberId?: string): Promise<KapsoPhoneNumber> {
+  const { phoneNumbers, settings } = await getTrackedPhoneNumbers();
+  const requestedPhoneNumberId = phoneNumberId?.trim() || settings.defaultPhoneNumberId;
+
+  if (!requestedPhoneNumberId) {
+    throw new InboxConfigurationError('No phone number selected in settings', 400);
+  }
+
+  if (!settings.selectedPhoneNumberIds.includes(requestedPhoneNumberId)) {
+    throw new InboxConfigurationError('Phone number is not selected in inbox settings', 400);
+  }
+
+  const phoneNumber = phoneNumbers.find(number => number.phone_number_id === requestedPhoneNumberId);
+  if (!phoneNumber) {
+    throw new InboxConfigurationError('Selected phone number was not found in Kapso', 404);
+  }
+
+  return phoneNumber;
+}
+
+export function configurationErrorResponse(error: unknown): Response {
+  const status = error instanceof InboxConfigurationError ? error.status : 500;
+  const message = error instanceof Error ? error.message : 'Inbox configuration error';
+
+  return Response.json(
+    { error: message },
+    { status }
+  );
+}

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,0 +1,38 @@
+export type KapsoPhoneNumber = {
+  id: string;
+  internal_id?: string;
+  phone_number_id: string;
+  name?: string;
+  business_account_id?: string;
+  is_coexistence?: boolean;
+  inbound_processing_enabled?: boolean;
+  calls_enabled?: boolean;
+  webhook_verified_at?: string | null;
+  created_at?: string;
+  updated_at?: string;
+  display_name?: string;
+  display_phone_number?: string;
+  display_phone_number_normalized?: string;
+  verified_name?: string;
+  quality_rating?: string;
+  throughput_tier?: string;
+  whatsapp_business_manager_messaging_limit?: string | number;
+  customer_id?: string;
+  code_verification_status?: string;
+  name_status?: string;
+  status?: string;
+  is_official_business_account?: boolean;
+  is_pin_enabled?: boolean;
+};
+
+export type InboxSettings = {
+  selectedPhoneNumberIds: string[];
+  defaultPhoneNumberId?: string;
+};
+
+export type InboxSettingsResponse = {
+  phoneNumbers: KapsoPhoneNumber[];
+  selectedPhoneNumberIds: string[];
+  defaultPhoneNumberId?: string;
+  hasStoredSettings: boolean;
+};


### PR DESCRIPTION
## Summary
- Discover WhatsApp phone numbers from Kapso using the API key and persist selected inbox numbers in an HTTP-only cookie
- Add a settings page for choosing tracked numbers and the default sender
- Thread selected phone-number context through conversations, messages, media, interactive sends, and templates
- Hide generated media URL metadata while preserving audio transcripts

## Checks
- npm run lint
- npm run build