### PR TITLE
Add inbox reply context and notifications

### DIFF
--- a/src/app/api/messages/[conversationId]/route.ts
+++ b/src/app/api/messages/[conversationId]/route.ts
@@ -75,6 +75,31 @@ function extractMediaData(mediaData: MediaData | undefined): Pick<MediaData, 'fi
   };
 }
 
+function readString(value: Record<string, unknown> | undefined, ...keys: string[]): string | undefined {
+  if (!value) return undefined;
+
+  for (const key of keys) {
+    const candidate = value[key];
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+function extractContextMessageId(
+  msg: MetaMessage,
+  kapsoExtensions: KapsoMessageExtensions | undefined,
+  messageTypeData: MessageTypeData | undefined
+): string | undefined {
+  return (
+    (typeof msg.context?.id === 'string' && msg.context.id) ||
+    readString(kapsoExtensions, 'contextMessageId', 'context_message_id') ||
+    readString(messageTypeData, 'contextMessageId', 'context_message_id')
+  );
+}
+
 function isGeneratedMediaAttachmentContent(content: string, mediaUrl?: string): boolean {
   const trimmedContent = content.trim();
   if (!trimmedContent) return false;
@@ -156,6 +181,7 @@ export async function GET(
       const kapsoExtensions = kapso as KapsoMessageExtensions | undefined;
       const messageTypeData = extractMessageTypeData(kapsoExtensions?.messageTypeData);
       const kapsoMediaData = extractMediaData(kapsoExtensions?.mediaData);
+      const contextMessageId = extractContextMessageId(msg, kapsoExtensions, messageTypeData);
 
       const mediaId =
         image?.id ??
@@ -219,6 +245,7 @@ export async function GET(
         reactedToMessageId: typeof reaction?.messageId === 'string'
           ? reaction.messageId
           : messageTypeData?.messageId,
+        contextMessageId,
         filename: document?.filename ?? messageTypeData?.filename ?? kapsoMediaData.filename,
         mimeType: messageTypeData?.mimeType ?? kapsoMediaData.contentType,
         messageType: msg.type,

--- a/src/app/api/messages/send/route.ts
+++ b/src/app/api/messages/send/route.ts
@@ -8,6 +8,7 @@ export async function POST(request: Request) {
     const to = formData.get('to') as string;
     const body = formData.get('body') as string;
     const file = formData.get('file') as File | null;
+    const contextMessageId = (formData.get('contextMessageId') as string | null)?.trim() || undefined;
     const configuredPhoneNumber = await resolvePhoneNumberContext(formData.get('phoneNumberId') as string | undefined);
     const phoneNumberId = configuredPhoneNumber.phone_number_id;
 
@@ -38,24 +39,28 @@ export async function POST(request: Request) {
         result = await whatsappClient.messages.sendImage({
           phoneNumberId,
           to,
+          contextMessageId,
           image: { id: uploadResult.id, caption: body || undefined }
         });
       } else if (mediaType === 'video') {
         result = await whatsappClient.messages.sendVideo({
           phoneNumberId,
           to,
+          contextMessageId,
           video: { id: uploadResult.id, caption: body || undefined }
         });
       } else if (mediaType === 'audio') {
         result = await whatsappClient.messages.sendAudio({
           phoneNumberId,
           to,
+          contextMessageId,
           audio: { id: uploadResult.id }
         });
       } else {
         result = await whatsappClient.messages.sendDocument({
           phoneNumberId,
           to,
+          contextMessageId,
           document: { id: uploadResult.id, caption: body || undefined, filename: file.name }
         });
       }
@@ -64,6 +69,7 @@ export async function POST(request: Request) {
       result = await whatsappClient.messages.sendText({
         phoneNumberId,
         to,
+        contextMessageId,
         body
       });
     } else {
@@ -73,7 +79,11 @@ export async function POST(request: Request) {
       );
     }
 
-    return NextResponse.json(result);
+    return NextResponse.json(
+      typeof result === 'object' && result !== null
+        ? { ...result, contextMessageId }
+        : { result, contextMessageId }
+    );
   } catch (error) {
     console.error('Error sending message:', error);
     return configurationErrorResponse(error);

--- a/src/components/conversation-list.tsx
+++ b/src/components/conversation-list.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
 import { differenceInDays, differenceInHours, differenceInMinutes, format, isValid, isYesterday } from 'date-fns';
-import { BellOff, Check, ChevronDown, Plus, RefreshCw, Search, Settings } from 'lucide-react';
+import { Bell, BellOff, Check, ChevronDown, Plus, RefreshCw, Search, Settings } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
   CONVERSATIONS_QUERY_KEY,
@@ -78,6 +78,61 @@ const FILTER_MENU_ITEMS = [
   { label: 'Handoff', disabled: true },
 ] as const;
 
+const NOTIFICATIONS_STORAGE_KEY = 'whatsapp-cloud-inbox-notifications-enabled';
+
+type NotificationPermissionState = NotificationPermission | 'unsupported';
+
+type ThreadNotificationSnapshot = {
+  lastActiveAt?: string;
+  messagesCount?: number;
+  lastMessageContent?: string;
+  lastMessageDirection?: string;
+};
+
+function parseTimestamp(timestamp?: string): number {
+  if (!timestamp) return 0;
+  const time = Date.parse(timestamp);
+  return Number.isFinite(time) ? time : 0;
+}
+
+function getThreadNotificationSnapshot(thread: ConversationThread): ThreadNotificationSnapshot {
+  return {
+    lastActiveAt: thread.lastActiveAt,
+    messagesCount: thread.latestConversation.messagesCount,
+    lastMessageContent: thread.lastMessage?.content,
+    lastMessageDirection: thread.lastMessage?.direction,
+  };
+}
+
+function shouldNotifyForThread(
+  thread: ConversationThread,
+  previousSnapshot: ThreadNotificationSnapshot | undefined,
+): boolean {
+  if (thread.lastMessage?.direction !== 'inbound') return false;
+  if (!previousSnapshot) return true;
+
+  const currentSnapshot = getThreadNotificationSnapshot(thread);
+  const currentCount = currentSnapshot.messagesCount;
+  const previousCount = previousSnapshot.messagesCount;
+
+  if (
+    typeof currentCount === 'number' &&
+    typeof previousCount === 'number' &&
+    currentCount > previousCount
+  ) {
+    return true;
+  }
+
+  if (parseTimestamp(currentSnapshot.lastActiveAt) > parseTimestamp(previousSnapshot.lastActiveAt)) {
+    return true;
+  }
+
+  return (
+    currentSnapshot.lastMessageContent !== previousSnapshot.lastMessageContent ||
+    currentSnapshot.lastMessageDirection !== previousSnapshot.lastMessageDirection
+  );
+}
+
 type Props = {
   onSelectThread: (thread: ConversationThread) => void;
   selectedThreadKey?: string;
@@ -90,8 +145,12 @@ export function ConversationList({ onSelectThread, selectedThreadKey, isHidden =
   const [refreshing, setRefreshing] = useState(false);
   const [isStatusMenuOpen, setIsStatusMenuOpen] = useState(false);
   const [isFilterMenuOpen, setIsFilterMenuOpen] = useState(false);
+  const [notificationPermission, setNotificationPermission] = useState<NotificationPermissionState>('default');
+  const [notificationsEnabled, setNotificationsEnabled] = useState(false);
   const controlsRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const previousThreadSnapshotsRef = useRef<Map<string, ThreadNotificationSnapshot>>(new Map());
+  const hasInitializedNotificationSnapshotsRef = useRef(false);
 
   const {
     data: conversations = [],
@@ -129,6 +188,103 @@ export function ConversationList({ onSelectThread, selectedThreadKey, isHidden =
     }
   };
 
+  const persistNotificationsEnabled = (enabled: boolean) => {
+    setNotificationsEnabled(enabled);
+
+    try {
+      window.localStorage.setItem(NOTIFICATIONS_STORAGE_KEY, String(enabled));
+    } catch {
+      // Notifications still work for this session even when storage is unavailable.
+    }
+  };
+
+  const handleNotificationsClick = async () => {
+    if (!('Notification' in window)) {
+      setNotificationPermission('unsupported');
+      persistNotificationsEnabled(false);
+      return;
+    }
+
+    if (notificationPermission === 'unsupported') return;
+
+    if (Notification.permission === 'granted') {
+      persistNotificationsEnabled(!notificationsEnabled);
+      setNotificationPermission('granted');
+      return;
+    }
+
+    if (Notification.permission === 'denied') {
+      setNotificationPermission('denied');
+      persistNotificationsEnabled(false);
+      return;
+    }
+
+    const permission = await Notification.requestPermission();
+    setNotificationPermission(permission);
+    persistNotificationsEnabled(permission === 'granted');
+  };
+
+  useEffect(() => {
+    if (!('Notification' in window)) {
+      setNotificationPermission('unsupported');
+      setNotificationsEnabled(false);
+      return;
+    }
+
+    setNotificationPermission(Notification.permission);
+
+    try {
+      setNotificationsEnabled(
+        window.localStorage.getItem(NOTIFICATIONS_STORAGE_KEY) === 'true' &&
+        Notification.permission === 'granted',
+      );
+    } catch {
+      setNotificationsEnabled(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const currentSnapshots = new Map(
+      threads.map((thread) => [thread.key, getThreadNotificationSnapshot(thread)]),
+    );
+
+    if (!hasInitializedNotificationSnapshotsRef.current) {
+      previousThreadSnapshotsRef.current = currentSnapshots;
+      hasInitializedNotificationSnapshotsRef.current = true;
+      return;
+    }
+
+    if (notificationsEnabled && notificationPermission === 'granted') {
+      threads.forEach((thread) => {
+        if (
+          document.visibilityState === 'visible' &&
+          selectedThreadKey === thread.key
+        ) {
+          return;
+        }
+
+        if (!shouldNotifyForThread(thread, previousThreadSnapshotsRef.current.get(thread.key))) {
+          return;
+        }
+
+        const title = thread.contactName || thread.phoneNumber || 'New WhatsApp message';
+        const body = thread.lastMessage?.content || 'New message received';
+        const notification = new Notification(title, {
+          body,
+          tag: `whatsapp-inbox:${thread.key}`,
+        });
+
+        notification.onclick = () => {
+          window.focus();
+          onSelectThread(thread);
+          notification.close();
+        };
+      });
+    }
+
+    previousThreadSnapshotsRef.current = currentSnapshots;
+  }, [notificationPermission, notificationsEnabled, onSelectThread, selectedThreadKey, threads]);
+
   useEffect(() => {
     if (!isStatusMenuOpen && !isFilterMenuOpen) return;
 
@@ -156,6 +312,15 @@ export function ConversationList({ onSelectThread, selectedThreadKey, isHidden =
   }, [isFilterMenuOpen, isStatusMenuOpen]);
 
   const selectedStatusLabel = STATUS_FILTERS.find(filter => filter.value === statusFilter)?.label || 'Active';
+  const notificationsActive = notificationsEnabled && notificationPermission === 'granted';
+  const notificationsButtonTitle =
+    notificationPermission === 'unsupported'
+      ? 'Notifications are not supported'
+      : notificationPermission === 'denied'
+        ? 'Notifications are blocked in browser settings'
+        : notificationsActive
+          ? 'Disable inbox notifications'
+          : 'Enable inbox notifications';
 
   if (isPending) {
     return (
@@ -167,6 +332,7 @@ export function ConversationList({ onSelectThread, selectedThreadKey, isHidden =
           <div className="mb-3 flex items-center justify-between pt-1">
             <Skeleton className="h-6 w-20" />
             <div className="flex items-center gap-2">
+              <Skeleton className="size-8" />
               <Skeleton className="size-8" />
               <Skeleton className="size-8" />
             </div>
@@ -213,6 +379,26 @@ export function ConversationList({ onSelectThread, selectedThreadKey, isHidden =
           <div className="flex items-center gap-1.5">
             <Button
               type="button"
+              onClick={handleNotificationsClick}
+              disabled={notificationPermission === 'unsupported' || notificationPermission === 'denied'}
+              variant="ghost"
+              size="icon"
+              className={cn(
+                "size-8 rounded-md text-muted-foreground hover:bg-[var(--chat-icon-hover)] hover:text-foreground",
+                notificationsActive && "text-primary hover:text-primary",
+              )}
+              aria-label={notificationsButtonTitle}
+              aria-pressed={notificationsActive}
+              title={notificationsButtonTitle}
+            >
+              {notificationsActive ? (
+                <Bell className="size-4" />
+              ) : (
+                <BellOff className="size-4" />
+              )}
+            </Button>
+            <Button
+              type="button"
               onClick={handleRefresh}
               disabled={refreshing}
               variant="ghost"
@@ -221,11 +407,7 @@ export function ConversationList({ onSelectThread, selectedThreadKey, isHidden =
               aria-label="Refresh conversations"
               title="Refresh conversations"
             >
-              {refreshing ? (
-                <RefreshCw className="size-4 animate-spin" />
-              ) : (
-                <BellOff className="size-4" />
-              )}
+              <RefreshCw className={cn("size-4", refreshing && "animate-spin")} />
             </Button>
             <Button
               asChild

--- a/src/components/message-view.tsx
+++ b/src/components/message-view.tsx
@@ -21,6 +21,7 @@ import {
   ListTree,
   ArrowLeft,
   Check,
+  Reply,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
@@ -177,6 +178,26 @@ function getDisabledInputMessage(messages: Message[]): string {
 }
 
 const MESSAGE_SKELETON_WIDTHS = [280, 180, 320, 210, 260, 170];
+const LOCAL_REPLY_CONTEXT_STORAGE_KEY = "whatsapp-cloud-inbox-reply-contexts";
+const LOCAL_REPLY_CONTEXT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+const MAX_LOCAL_REPLY_CONTEXTS = 200;
+
+type RepliedToMessage = NonNullable<Message["repliedTo"]>;
+
+type LocalReplyContext = {
+  contextMessageId: string;
+  repliedTo: RepliedToMessage;
+  createdAt: number;
+};
+
+type LocalReplyContexts = Record<string, LocalReplyContext>;
+
+type SendMessageResult = {
+  messages?: Array<{ id?: string }>;
+  messageId?: string;
+  id?: string;
+  contextMessageId?: string;
+};
 
 function extractTranscriptDisplayContent(content: string): string | undefined {
   const match = content.match(/\bTranscript:\s*[\s\S]*$/i);
@@ -217,6 +238,55 @@ function getDisplayMessageContent(message: Message): string | null {
   return trimmedContent;
 }
 
+function getReplyPreviewContent(message: Message): string {
+  const content = getDisplayMessageContent(message) || message.caption || message.filename || '';
+  const trimmedContent = content.trim();
+
+  if (trimmedContent) {
+    return trimmedContent.length > 140 ? `${trimmedContent.slice(0, 137)}...` : trimmedContent;
+  }
+
+  if (message.hasMedia && message.messageType) {
+    return `${message.messageType.charAt(0).toUpperCase()}${message.messageType.slice(1)} message`;
+  }
+
+  return 'Message';
+}
+
+function getMessageSenderLabel(
+  message: Pick<Message, 'direction'>,
+  contactName?: string,
+  phoneNumber?: string,
+): string {
+  if (message.direction === 'outbound') return 'you';
+  return contactName || phoneNumber || 'contact';
+}
+
+function extractSentMessageId(result: unknown): string | null {
+  if (!result || typeof result !== "object") return null;
+
+  const sendResult = result as SendMessageResult;
+  const sentMessageId = sendResult.messages?.find((message) => typeof message.id === "string")?.id;
+
+  return sentMessageId ?? sendResult.messageId ?? sendResult.id ?? null;
+}
+
+function pruneLocalReplyContexts(contexts: LocalReplyContexts): LocalReplyContexts {
+  const now = Date.now();
+  const entries = Object.entries(contexts)
+    .filter(([, context]) => (
+      context &&
+      typeof context.contextMessageId === "string" &&
+      context.repliedTo &&
+      typeof context.repliedTo.id === "string" &&
+      now - context.createdAt < LOCAL_REPLY_CONTEXT_MAX_AGE_MS
+    ))
+    .sort(([, a], [, b]) => b.createdAt - a.createdAt)
+    .slice(0, MAX_LOCAL_REPLY_CONTEXTS);
+
+  return Object.fromEntries(entries);
+}
+
 type Props = {
   conversationId?: string;
   conversations?: Conversation[];
@@ -253,10 +323,16 @@ export function MessageView({
   const [showTemplateDialog, setShowTemplateDialog] = useState(false);
   const [showInteractiveDialog, setShowInteractiveDialog] = useState(false);
   const [isNearBottom, setIsNearBottom] = useState(true);
+  const [replyingToMessage, setReplyingToMessage] = useState<Message | null>(null);
+  const [highlightedMessageId, setHighlightedMessageId] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
+  const messageInputRef = useRef<HTMLInputElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const lastInitialScrollKeyRef = useRef("");
+  const highlightTimeoutRef = useRef<number | null>(null);
+  const localReplyContextsRef = useRef<LocalReplyContexts>({});
+  const [localReplyContextVersion, setLocalReplyContextVersion] = useState(0);
   const queryClient = useQueryClient();
   const lastSeenText = formatLastSeen(lastActiveAt);
   const displayPhoneNumber = formatDisplayPhoneNumber(phoneNumber);
@@ -318,6 +394,91 @@ export function MessageView({
     scrollToBottom();
   }, [conversationId, getScrollViewport, scrollToBottom]);
 
+  const scrollToMessage = useCallback((messageId: string) => {
+    const viewport = getScrollViewport();
+    if (!viewport) return;
+
+    const targetMessage = Array.from(
+      viewport.querySelectorAll<HTMLElement>("[data-message-id]"),
+    ).find((element) => element.dataset.messageId === messageId);
+
+    if (!targetMessage) return;
+
+    targetMessage.scrollIntoView({ behavior: "smooth", block: "center" });
+    setHighlightedMessageId(messageId);
+
+    if (highlightTimeoutRef.current !== null) {
+      window.clearTimeout(highlightTimeoutRef.current);
+    }
+
+    highlightTimeoutRef.current = window.setTimeout(() => {
+      setHighlightedMessageId(null);
+      highlightTimeoutRef.current = null;
+    }, 2_000);
+  }, [getScrollViewport]);
+
+  const handleReplyToMessage = useCallback((message: Message) => {
+    setReplyingToMessage(message);
+    window.requestAnimationFrame(() => {
+      messageInputRef.current?.focus();
+    });
+  }, []);
+
+  const handleCancelReply = useCallback(() => {
+    setReplyingToMessage(null);
+  }, []);
+
+  const persistLocalReplyContexts = useCallback((contexts: LocalReplyContexts) => {
+    const prunedContexts = pruneLocalReplyContexts(contexts);
+    localReplyContextsRef.current = prunedContexts;
+    setLocalReplyContextVersion((version) => version + 1);
+
+    try {
+      window.localStorage.setItem(
+        LOCAL_REPLY_CONTEXT_STORAGE_KEY,
+        JSON.stringify(prunedContexts),
+      );
+    } catch {
+      // Keeping the in-memory map is enough for the current session.
+    }
+  }, []);
+
+  const rememberLocalReplyContext = useCallback((sentMessageId: string, replyTarget: Message) => {
+    persistLocalReplyContexts({
+      ...localReplyContextsRef.current,
+      [sentMessageId]: {
+        contextMessageId: replyTarget.id,
+        repliedTo: {
+          id: replyTarget.id,
+          conversationId: replyTarget.conversationId,
+          content: getReplyPreviewContent(replyTarget),
+          direction: replyTarget.direction,
+          messageType: replyTarget.messageType,
+          senderName: getMessageSenderLabel(replyTarget, contactName, phoneNumber),
+        },
+        createdAt: Date.now(),
+      },
+    });
+  }, [contactName, persistLocalReplyContexts, phoneNumber]);
+
+  const applyLocalReplyContexts = useCallback((inputMessages: Message[]) => {
+    const localReplyContexts = localReplyContextsRef.current;
+    if (Object.keys(localReplyContexts).length === 0) return inputMessages;
+
+    return inputMessages.map((message) => {
+      if (message.contextMessageId || message.repliedTo) return message;
+
+      const localReplyContext = localReplyContexts[message.id];
+      if (!localReplyContext) return message;
+
+      return {
+        ...message,
+        contextMessageId: localReplyContext.contextMessageId,
+        repliedTo: localReplyContext.repliedTo,
+      };
+    });
+  }, []);
+
   const fetchThreadMessages = useCallback(async () => {
     if (threadConversationIds.length === 0) return [];
 
@@ -339,8 +500,8 @@ export function MessageView({
       }),
     );
 
-    return normalizeMessages(messageBatches.flat());
-  }, [phoneNumberId, queryClient, threadConversationIds]);
+    return applyLocalReplyContexts(normalizeMessages(messageBatches.flat()));
+  }, [applyLocalReplyContexts, phoneNumberId, queryClient, threadConversationIds]);
 
   const { data: messages = [], isPending: loading } = useQuery({
     queryKey: threadMessagesQueryKey,
@@ -349,6 +510,30 @@ export function MessageView({
     refetchInterval: 5_000,
     refetchOnMount: false,
   });
+
+  useEffect(() => {
+    try {
+      const storedContexts = window.localStorage.getItem(LOCAL_REPLY_CONTEXT_STORAGE_KEY);
+      if (!storedContexts) return;
+
+      const parsedContexts = JSON.parse(storedContexts);
+      if (parsedContexts && typeof parsedContexts === "object" && !Array.isArray(parsedContexts)) {
+        persistLocalReplyContexts(parsedContexts as LocalReplyContexts);
+      }
+    } catch {
+      localReplyContextsRef.current = {};
+    }
+  }, [persistLocalReplyContexts]);
+
+  useEffect(() => {
+    const currentMessages = queryClient.getQueryData<Message[]>(threadMessagesQueryKey);
+    if (!currentMessages) return;
+
+    queryClient.setQueryData(
+      threadMessagesQueryKey,
+      applyLocalReplyContexts(currentMessages),
+    );
+  }, [applyLocalReplyContexts, localReplyContextVersion, queryClient, threadMessagesQueryKey]);
 
   const refreshCurrentThread = useCallback(async () => {
     if (threadConversationIds.length === 0) return;
@@ -365,9 +550,9 @@ export function MessageView({
 
     queryClient.setQueryData(
       threadMessagesQueryKey,
-      normalizeMessages(messageBatches.flat()),
+      applyLocalReplyContexts(normalizeMessages(messageBatches.flat())),
     );
-  }, [phoneNumberId, queryClient, threadConversationIds, threadMessagesQueryKey]);
+  }, [applyLocalReplyContexts, phoneNumberId, queryClient, threadConversationIds, threadMessagesQueryKey]);
 
   useEffect(() => {
     if (isNearBottom) {
@@ -443,6 +628,24 @@ export function MessageView({
     setCanSendRegularMessage(isWithin24HourWindow(messages));
   }, [messages]);
 
+  useEffect(() => {
+    setReplyingToMessage(null);
+  }, [threadKey]);
+
+  useEffect(() => {
+    if (!canSendRegularMessage) {
+      setReplyingToMessage(null);
+    }
+  }, [canSendRegularMessage]);
+
+  useEffect(() => {
+    return () => {
+      if (highlightTimeoutRef.current !== null) {
+        window.clearTimeout(highlightTimeoutRef.current);
+      }
+    };
+  }, []);
+
   // Track if user is near bottom of scroll
   useEffect(() => {
     const container = messagesContainerRef.current;
@@ -509,12 +712,16 @@ export function MessageView({
     if ((!messageInput.trim() && !selectedFile) || !phoneNumber || sending)
       return;
 
+    const replyTarget = replyingToMessage;
     setSending(true);
     try {
       const formData = new FormData();
       formData.append("to", phoneNumber);
       if (phoneNumberId) {
         formData.append("phoneNumberId", phoneNumberId);
+      }
+      if (replyingToMessage?.id) {
+        formData.append("contextMessageId", replyingToMessage.id);
       }
       if (messageInput.trim()) {
         formData.append("body", messageInput);
@@ -523,12 +730,23 @@ export function MessageView({
         formData.append("file", selectedFile);
       }
 
-      await fetch("/api/messages/send", {
+      const response = await fetch("/api/messages/send", {
         method: "POST",
         body: formData,
       });
+      const data = await response.json().catch(() => null);
+
+      if (!response.ok) {
+        throw new Error(data?.error || "Failed to send message");
+      }
+
+      const sentMessageId = extractSentMessageId(data);
+      if (sentMessageId && replyTarget) {
+        rememberLocalReplyContext(sentMessageId, replyTarget);
+      }
 
       setMessageInput("");
+      setReplyingToMessage(null);
       handleRemoveFile();
       await queryClient.invalidateQueries({
         queryKey: CONVERSATIONS_QUERY_KEY,
@@ -707,6 +925,7 @@ export function MessageView({
                 prevMessage,
               );
               const displayMessageContent = getDisplayMessageContent(message);
+              const isHighlighted = highlightedMessageId === message.id;
 
               return (
                 <div
@@ -736,20 +955,54 @@ export function MessageView({
 
                   <div
                     className={cn(
-                      "flex mb-2",
+                      "group flex mb-2 items-start gap-1.5 rounded-lg px-1 py-0.5 transition-colors",
                       message.direction === "outbound"
                         ? "justify-end"
                         : "justify-start",
+                      isHighlighted && "bg-primary/10",
                     )}
                   >
+                    {message.direction === "outbound" && canSendRegularMessage && (
+                      <Button
+                        type="button"
+                        onClick={() => handleReplyToMessage(message)}
+                        variant="ghost"
+                        size="icon"
+                        className="mt-1 size-7 flex-shrink-0 text-muted-foreground opacity-100 hover:bg-[var(--chat-hover)] sm:opacity-0 sm:group-hover:opacity-100"
+                        aria-label="Reply to message"
+                        title="Reply"
+                      >
+                        <Reply className="h-3.5 w-3.5" />
+                      </Button>
+                    )}
                     <div
                       className={cn(
-                        "relative max-w-[min(88%,34rem)] rounded-lg px-3 py-2 shadow-sm sm:max-w-[min(78%,38rem)] lg:max-w-[min(70%,42rem)]",
+                        "relative max-w-[min(88%,34rem)] rounded-lg px-3 py-2 shadow-sm transition-shadow sm:max-w-[min(78%,38rem)] lg:max-w-[min(70%,42rem)]",
                         message.direction === "outbound"
                           ? "bg-[var(--chat-bubble-outgoing)] text-foreground rounded-br-none"
                           : "bg-[var(--chat-bubble-incoming)] text-foreground rounded-bl-none",
+                        isHighlighted && "ring-2 ring-primary/35",
                       )}
                     >
+                      {message.repliedTo && (
+                        <button
+                          type="button"
+                          onClick={() => scrollToMessage(message.repliedTo!.id)}
+                          className="mb-2 block w-full rounded border-l-2 border-primary/60 bg-background/45 px-2 py-1.5 text-left hover:bg-background/70"
+                        >
+                          <span className="flex min-w-0 items-center gap-1 text-[11px] font-medium text-primary">
+                            <Reply className="h-3 w-3 flex-shrink-0" />
+                            <span className="truncate">
+                              {message.repliedTo.senderName ||
+                                getMessageSenderLabel(message.repliedTo, contactName, phoneNumber)}
+                            </span>
+                          </span>
+                          <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+                            {message.repliedTo.content}
+                          </span>
+                        </button>
+                      )}
+
                       {message.hasMedia && message.mediaData?.url ? (
                         <div className="mb-2">
                           {message.messageType === "sticker" ? (
@@ -859,6 +1112,19 @@ export function MessageView({
                         </div>
                       )}
                     </div>
+                    {message.direction === "inbound" && canSendRegularMessage && (
+                      <Button
+                        type="button"
+                        onClick={() => handleReplyToMessage(message)}
+                        variant="ghost"
+                        size="icon"
+                        className="mt-1 size-7 flex-shrink-0 text-muted-foreground opacity-100 hover:bg-[var(--chat-hover)] sm:opacity-0 sm:group-hover:opacity-100"
+                        aria-label="Reply to message"
+                        title="Reply"
+                      >
+                        <Reply className="h-3.5 w-3.5" />
+                      </Button>
+                    )}
                   </div>
                 </div>
               );
@@ -871,6 +1137,33 @@ export function MessageView({
       <div className="border-t border-[var(--chat-border-strong)] bg-[var(--chat-toolbar)] safe-area-bottom">
         {canSendRegularMessage ? (
           <>
+            {replyingToMessage && (
+              <div className="border-b border-[var(--chat-border-strong)] bg-[var(--chat-surface)] px-3 py-2">
+                <div className="mx-auto flex w-full max-w-[900px] items-center gap-2">
+                  <Reply className="h-4 w-4 flex-shrink-0 text-primary" />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-xs font-medium text-primary">
+                      Replying to {getMessageSenderLabel(replyingToMessage, contactName, phoneNumber)}
+                    </p>
+                    <p className="truncate text-xs text-muted-foreground">
+                      {getReplyPreviewContent(replyingToMessage)}
+                    </p>
+                  </div>
+                  <Button
+                    onClick={handleCancelReply}
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-8 flex-shrink-0 text-muted-foreground"
+                    aria-label="Cancel reply"
+                    title="Cancel reply"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            )}
+
             {selectedFile && (
               <div className="border-b border-[var(--chat-border-strong)] bg-[var(--chat-surface)] p-3">
                 <div className="mx-auto flex w-full max-w-[900px] items-start gap-3">
@@ -943,6 +1236,7 @@ export function MessageView({
                 <ListTree className="h-5 w-5" />
               </Button>
               <Input
+                ref={messageInputRef}
                 type="text"
                 value={messageInput}
                 onChange={(e) => setMessageInput(e.target.value)}

--- a/src/lib/inbox-data.ts
+++ b/src/lib/inbox-data.ts
@@ -38,6 +38,15 @@ export type Message = {
   } | (MediaData & { url: string });
   reactionEmoji?: string | null;
   reactedToMessageId?: string | null;
+  contextMessageId?: string | null;
+  repliedTo?: {
+    id: string;
+    conversationId: string;
+    content: string;
+    direction: 'inbound' | 'outbound';
+    messageType?: string;
+    senderName?: string;
+  } | null;
   filename?: string | null;
   mimeType?: string | null;
   messageType?: string;
@@ -207,10 +216,26 @@ export function shortConversationId(conversationId?: string): string {
   return conversationId.replace(/-/g, '').slice(0, 8);
 }
 
+function getReplyPreviewContent(message: Message): string {
+  const content = message.caption || message.content || message.filename || '';
+  const trimmedContent = content.trim();
+
+  if (trimmedContent) {
+    return trimmedContent.length > 120 ? `${trimmedContent.slice(0, 117)}...` : trimmedContent;
+  }
+
+  if (message.hasMedia && message.messageType) {
+    return `${message.messageType.charAt(0).toUpperCase()}${message.messageType.slice(1)} message`;
+  }
+
+  return 'Message';
+}
+
 export function normalizeMessages(messages: Message[]): Message[] {
   const reactions = messages.filter(message => message.messageType === 'reaction');
   const regularMessages = messages.filter(message => message.messageType !== 'reaction');
   const reactionMap = new Map<string, string>();
+  const messageMap = new Map(regularMessages.map(message => [message.id, message]));
 
   reactions.forEach((reaction) => {
     if (reaction.reactedToMessageId && reaction.reactionEmoji) {
@@ -221,7 +246,34 @@ export function normalizeMessages(messages: Message[]): Message[] {
   return regularMessages
     .map((message) => {
       const reaction = reactionMap.get(message.id);
-      return reaction ? { ...message, reactionEmoji: reaction } : message;
+      const contextMessageId = message.contextMessageId?.trim();
+      const repliedMessage = contextMessageId ? messageMap.get(contextMessageId) : undefined;
+      const repliedTo = message.repliedTo ?? (
+        repliedMessage
+          ? {
+              id: repliedMessage.id,
+              conversationId: repliedMessage.conversationId,
+              content: getReplyPreviewContent(repliedMessage),
+              direction: repliedMessage.direction,
+              messageType: repliedMessage.messageType,
+              senderName: repliedMessage.direction === 'outbound' ? 'You' : 'Contact',
+            }
+          : contextMessageId
+            ? {
+                id: contextMessageId,
+                conversationId: message.conversationId,
+                content: 'Original message',
+                direction: 'inbound' as const,
+                senderName: 'Contact',
+              }
+            : undefined
+      );
+
+      return {
+        ...message,
+        ...(reaction ? { reactionEmoji: reaction } : {}),
+        ...(repliedTo ? { repliedTo } : {}),
+      };
     })
     .sort((a, b) => parseTimestamp(a.createdAt) - parseTimestamp(b.createdAt));
 }


### PR DESCRIPTION
## Summary
- add reply-to selection and quoted-message previews in the inbox composer/thread
- pass WhatsApp reply context through sends and preserve local outbound reply previews after refetch
- restore notifications as a separate bell control for newly arrived inbound messages

## Verification
- npm run lint
- npm run build